### PR TITLE
Fix incorrect copy constructor in cerr

### DIFF
--- a/api-server/src/util/IOstream.hpp
+++ b/api-server/src/util/IOstream.hpp
@@ -59,7 +59,7 @@ namespace redsafe::apiserver::util
         {
         }
 
-        explicit cerr(const cout&) = delete;
+        explicit cerr(const cerr&) = delete;
         ~cerr() = default;
 
         template<typename T>


### PR DESCRIPTION
## Summary
- correct the deleted copy constructor in `cerr`

## Testing
- `cmake ..` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_683fc0e73928832e998a7b6ba307be12