### PR TITLE
Refactor controller with folly F14FastMap

### DIFF
--- a/api-server/CMakeLists.txt
+++ b/api-server/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(OpenSSL REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(libpqxx CONFIG QUIET)
 find_package(libsodium CONFIG QUIET)
+find_package(folly CONFIG QUIET)
 
 if (TARGET libpqxx::pqxx)                       # 成功找到
     set(PQXX_TARGET libpqxx::pqxx)
@@ -64,15 +65,27 @@ else ()                                         # 回退到 pkg-config
     find_package(PkgConfig REQUIRED)    
     pkg_check_modules(sodium_PKG QUIET libsodium)
     add_library(sodium_PKG INTERFACE)
-    target_include_directories(sodium_PKG INTERFACE ${sodium_PKG_INCLUDE_DIRS})
-    target_link_libraries(sodium_PKG INTERFACE ${sodium_PKG_LINK_LIBRARIES})
-    set(sodium_PKG_TARGET sodium_PKG)
+  target_include_directories(sodium_PKG INTERFACE ${sodium_PKG_INCLUDE_DIRS})
+  target_link_libraries(sodium_PKG INTERFACE ${sodium_PKG_LINK_LIBRARIES})
+  set(sodium_PKG_TARGET sodium_PKG)
+endif()
+
+if (TARGET folly::folly)
+    set(FOLLY_TARGET folly::folly)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(FOLLY QUIET folly)
+    add_library(folly_pkg INTERFACE)
+    target_include_directories(folly_pkg INTERFACE ${FOLLY_INCLUDE_DIRS})
+  target_link_libraries(folly_pkg INTERFACE ${FOLLY_LINK_LIBRARIES})
+  set(FOLLY_TARGET folly_pkg)
 endif()
 
 target_include_directories(RED_Safe_apiserver
     PRIVATE
-      ${Boost_INCLUDE_DIRS}
-      ${nlohmann_json_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${nlohmann_json_INCLUDE_DIRS}
+  $<TARGET_PROPERTY:${FOLLY_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_link_libraries(RED_Safe_apiserver
     PRIVATE
@@ -81,4 +94,5 @@ target_link_libraries(RED_Safe_apiserver
       ${nlohmann_json_LIBS}
       ${PQXX_TARGET}
       ${sodium_PKG_TARGET}
+      ${FOLLY_TARGET}
 )

--- a/api-server/src/core/controller.cpp
+++ b/api-server/src/core/controller.cpp
@@ -12,7 +12,8 @@
    For licensing inquiries or to obtain a formal license, please contact:
 ******************************************************************************/
 
-#include <unordered_map>
+#include <folly/container/F14Map.h>
+#include <folly/String.h>
 #include <functional>
 
 #include "controller.hpp"
@@ -33,8 +34,8 @@ namespace redsafe::apiserver
 
     response Controller::handle_request() const
     {
-        static const std::unordered_map<
-            std::string,
+        static const folly::F14FastMap<
+            folly::StringPiece,
             std::function<util::Result(const http::request<http::string_body>&)>> POST_map =
         {
             {"/edge/signup", [](const http::request<http::string_body>& req)
@@ -246,8 +247,8 @@ namespace redsafe::apiserver
             }},
         };
 
-        static const std::unordered_map<
-            std::string,
+        static const folly::F14FastMap<
+            folly::StringPiece,
             std::function<util::Result(const http::request<http::string_body>&)>> GET_map =
         {
             {"/user/all", [this](const http::request<http::string_body>& req)
@@ -268,7 +269,7 @@ namespace redsafe::apiserver
 
         if (req_.method() == http::verb::get)
         {
-            if (const auto it = GET_map.find(req_.target()); it != GET_map.end())
+            if (const auto it = GET_map.find(folly::StringPiece{req_.target()}); it != GET_map.end())
                 ResponseBody = it->second(req_);
             else
                 return make_response(
@@ -277,7 +278,7 @@ namespace redsafe::apiserver
         }
         else if (req_.method() == http::verb::post)
         {
-            if (const auto it = POST_map.find(req_.target()); it != POST_map.end())
+            if (const auto it = POST_map.find(folly::StringPiece{req_.target()}); it != POST_map.end())
                 ResponseBody = it->second(req_);
             else
                 return make_response(


### PR DESCRIPTION
## Summary
- integrate Folly as an optional dependency
- refactor `Controller` to use `folly::F14FastMap` for endpoint lookup

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: fatal error: folly/container/F14Map.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6797130832ea5a251a45b14e147