### PR TITLE
Reformat api-server to Folly style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 100
+BreakBeforeBraces: Attach

--- a/api-server/config.hpp
+++ b/api-server/config.hpp
@@ -1,14 +1,14 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
@@ -27,14 +27,15 @@
 #endif
 
 #ifndef SQL_CONNECTION_STR
-#define SQL_CONNECTION_STR "host=127.0.0.1 port=5432 dbname=redsafedb user=redsafedb_user password=redsafedb_1204"
+#define SQL_CONNECTION_STR \
+  "host=127.0.0.1 port=5432 dbname=redsafedb user=redsafedb_user password=redsafedb_1204"
 #endif
 
 #ifndef SERVER_THREAD_TYPE
-#define SERVER_THREAD_TYPE 1 // 0 -> single_thread,  1 -> std::jthread, 2 -> boost.asio.thread_pool
+#define SERVER_THREAD_TYPE 1  // 0 -> single_thread,  1 -> std::jthread, 2 -> boost.asio.thread_pool
 #endif
 
 // 金鑰檔案名稱 (執行程式目錄)
-static constexpr auto SECRET_FILE_PATH  = "jwt_secret.txt";
+static constexpr auto SECRET_FILE_PATH = "jwt_secret.txt";
 
 static constexpr auto AES_KEY_FILE_PATH = "AES_KEY.txt";

--- a/api-server/include/api-server.hpp
+++ b/api-server/include/api-server.hpp
@@ -1,14 +1,14 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
@@ -16,18 +16,17 @@
 
 #include <memory>
 
-namespace redsafe::apiserver
-{
-    class Server
-    {
-    public:
-        explicit Server(uint16_t port);
-        ~Server();
+namespace redsafe::apiserver {
+class Server {
+ public:
+  explicit Server(uint16_t port);
+  ~Server();
 
-        void start() const;
-        void stop() const;
-    private:
-        class Impl;
-        std::unique_ptr<Impl> impl_;
-    };
-}
+  void start() const;
+  void stop() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+}  // namespace redsafe::apiserver

--- a/api-server/main.cpp
+++ b/api-server/main.cpp
@@ -1,43 +1,37 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
 #include <iostream>
 
-#include "include/api-server.hpp"
 #include "config.hpp"
+#include "include/api-server.hpp"
 
-int main(const int argc, char* argv[])
-{
-    try
-    {
-        const redsafe::apiserver::Server server(SERVER_PORT);
-        server.start();
-        while (true)
-        {
-            std::string input;
-            // std::cout << "RED-Safe~/$ ";
-            std::getline(std::cin, input);
-            if (input == "exit")
-                return 0;
-            if (input == "clear")
-                [[maybe_unused]] auto e = system("clear");
-        }
+int main(const int argc, char* argv[]) {
+  try {
+    const redsafe::apiserver::Server server(SERVER_PORT);
+    server.start();
+    while (true) {
+      std::string input;
+      // std::cout << "RED-Safe~/$ ";
+      std::getline(std::cin, input);
+      if (input == "exit") return 0;
+      if (input == "clear") [[maybe_unused]]
+        auto e = system("clear");
     }
-    catch(const std::exception& e)
-    {
-        std::cerr << "Server error: " << e.what() << "\n";
-        std::cin.get();
-        return 1;
-    }
+  } catch (const std::exception& e) {
+    std::cerr << "Server error: " << e.what() << "\n";
+    std::cin.get();
+    return 1;
+  }
 }

--- a/api-server/src/core/api-server.cpp
+++ b/api-server/src/core/api-server.cpp
@@ -1,167 +1,133 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
+
+#include "../../include/api-server.hpp"
 
 #include <boost/asio.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <memory>
 #include <thread>
 
-#include "session.hpp"
-#include "../util/logger.hpp"
-#include "../util/IOstream.hpp"
 #include "../../config.hpp"
-#include "../../include/api-server.hpp"
+#include "../util/IOstream.hpp"
+#include "../util/logger.hpp"
+#include "session.hpp"
 
 using namespace boost::asio;
 using tcp = ip::tcp;
 
-namespace redsafe::apiserver
-{
-    class Server::Impl
-    {
-    public:
-        explicit Impl(const uint16_t port)
-            : acceptor_{io_, {tcp::v4(), port}}
-        {
-            acceptor_.listen(1024);
-        }
+namespace redsafe::apiserver {
+class Server::Impl {
+ public:
+  explicit Impl(const uint16_t port) : acceptor_{io_, {tcp::v4(), port}} { acceptor_.listen(1024); }
 
-        ~Impl()
-        {
-            stop();
-        }
+  ~Impl() { stop(); }
 
-        void start()
-        {
-            loggerinit();
-            do_accept();
-            threadscreater();
-            util::log(util::LogFile::server, util::Level::INFO)
-                    << "Server listening on port: " << acceptor_.local_endpoint().port()
-                    << " Threads: " << numThreads;
-            clearandprintlogo(std::to_string(acceptor_.local_endpoint().port()),
-                      std::to_string(numThreads)
-            );
-        }
+  void start() {
+    loggerinit();
+    do_accept();
+    threadscreater();
+    util::log(util::LogFile::server, util::Level::INFO)
+        << "Server listening on port: " << acceptor_.local_endpoint().port()
+        << " Threads: " << numThreads;
+    clearandprintlogo(std::to_string(acceptor_.local_endpoint().port()),
+                      std::to_string(numThreads));
+  }
 
-        void stop()
-        {
-            io_.stop();
+  void stop() {
+    io_.stop();
 #if SERVER_THREAD_TYPE == 2
-            if (pool_)
-                pool_->join();
+    if (pool_) pool_->join();
 #endif
-        }
+  }
 
-    private:
-        void do_accept()
-        {
-            acceptor_.async_accept(
-                [this](auto ec, tcp::socket socket)
-                {
-                    if (ec)
-                    {
-                        util::log(util::LogFile::server, util::Level::ERROR)
-                                  << "Accept failed: " << ec.message();
-                        std::cerr << "Accept failed: " << ec.message() << '\n';
-                    }
-                    boost::asio::post(io_, [this]() { do_accept(); });
-                    auto addr = socket.remote_endpoint().address().to_string();
-                    auto port = socket.remote_endpoint().port();
-                    std::make_shared<Session>(std::move(socket))->start();
-                    util::cout() << util::current_timestamp()
-                            << "nginx connection: "
-                            << addr << ':' << port << '\n';
-                }
-            );
-        }
+ private:
+  void do_accept() {
+    acceptor_.async_accept([this](auto ec, tcp::socket socket) {
+      if (ec) {
+        util::log(util::LogFile::server, util::Level::ERROR) << "Accept failed: " << ec.message();
+        std::cerr << "Accept failed: " << ec.message() << '\n';
+      }
+      boost::asio::post(io_, [this]() { do_accept(); });
+      auto addr = socket.remote_endpoint().address().to_string();
+      auto port = socket.remote_endpoint().port();
+      std::make_shared<Session>(std::move(socket))->start();
+      util::cout() << util::current_timestamp() << "nginx connection: " << addr << ':' << port
+                   << '\n';
+    });
+  }
 
-        static void loggerinit()
-        {
-            util::LoggerManager::init(util::LogFile::server,SERVER_LOGFILE_PATH);
-            util::LoggerManager::init(util::LogFile::access, ACCESS_LOGFILE_PATH);
-        }
+  static void loggerinit() {
+    util::LoggerManager::init(util::LogFile::server, SERVER_LOGFILE_PATH);
+    util::LoggerManager::init(util::LogFile::access, ACCESS_LOGFILE_PATH);
+  }
 
-        void threadscreater()
-        {
-#if  SERVER_THREAD_TYPE == 0
-            numThreads = 1;
-            io_.run();
+  void threadscreater() {
+#if SERVER_THREAD_TYPE == 0
+    numThreads = 1;
+    io_.run();
 #else
-            if (numThreads == 0) numThreads = 2;
-#if  SERVER_THREAD_TYPE == 1
-            workers.reserve(numThreads);
-            for (unsigned int i = 0; i < numThreads; ++i)
-                workers.emplace_back([this](const std::stop_token &) { io_.run(); });
+    if (numThreads == 0) numThreads = 2;
+#if SERVER_THREAD_TYPE == 1
+    workers.reserve(numThreads);
+    for (unsigned int i = 0; i < numThreads; ++i)
+      workers.emplace_back([this](const std::stop_token &) { io_.run(); });
 #elif SERVER_THREAD_TYPE == 2
-            pool_ = std::make_unique<thread_pool>(numThreads);
-            for (unsigned int i = 0; i < numThreads; ++i)
-                post(*pool_, [ctx = &io_]{ ctx->run(); });
+    pool_ = std::make_unique<thread_pool>(numThreads);
+    for (unsigned int i = 0; i < numThreads; ++i) post(*pool_, [ctx = &io_] { ctx->run(); });
 #endif
 #endif
-        }
+  }
 
-        static void clearandprintlogo(const std::string &port, const std::string &threadnumbers)
-        {
-            [[maybe_unused]] auto e = system("clear");
-            std::cout
-                    << " _____   ______  _____            _____          __\n"
-                    << "|  __ \\ |  ____||  __ \\          / ____|        / _|\n"
-                    << "| |__) || |__   | |  | | ______ | (___    __ _ | |_   ___\n"
-                    << "|  _  / |  __|  | |  | ||______| \\___ \\  / _` ||  _| / _ \\\n"
-                    << "| | \\ \\ | |____ | |__| |         ____) || (_| || |  |  __/\n"
-                    << "|_|  \\_\\|______||_____/         |_____/  \\__,_||_|   \\___|\n"
-                    << "-----------------------------------------------------------\n";
-            {
-                constexpr int total_width = 59;
-                constexpr int inner_width = total_width - 2;
-                const std::string port_msg = "Server listening on port: " + port;
-                const int pad1 = (inner_width - static_cast<int>(port_msg.size())) / 2;
-                const int pad2 = inner_width - pad1 - static_cast<int>(port_msg.size());
-                std::cout << "-"
-                        << std::string(pad1, ' ') << port_msg << std::string(pad2, ' ')
-                        << "-" << "\n";
-                const std::string thread_msg = "Threads: " + threadnumbers;
-                const int pad3 = (inner_width - static_cast<int>(thread_msg.size())) / 2;
-                const int pad4 = inner_width - pad3 - static_cast<int>(thread_msg.size());
-                std::cout << "-"
-                        << std::string(pad3, ' ') << thread_msg << std::string(pad4, ' ')
-                        << "-" << "\n";
-            }
-            std::cout << "-----------------------------------------------------------\n";
-        }
-
-        io_context                      io_;
-        ip::tcp::acceptor               acceptor_;
-        std::unique_ptr<thread_pool>    pool_;
-        std::vector<std::jthread>       workers;
-        unsigned int numThreads = std::thread::hardware_concurrency();
-    };
-
-    Server::Server(const uint16_t port) : impl_{std::make_unique<Impl>(port)}
+  static void clearandprintlogo(const std::string &port, const std::string &threadnumbers) {
+    [[maybe_unused]] auto e = system("clear");
+    std::cout << " _____   ______  _____            _____          __\n"
+              << "|  __ \\ |  ____||  __ \\          / ____|        / _|\n"
+              << "| |__) || |__   | |  | | ______ | (___    __ _ | |_   ___\n"
+              << "|  _  / |  __|  | |  | ||______| \\___ \\  / _` ||  _| / _ \\\n"
+              << "| | \\ \\ | |____ | |__| |         ____) || (_| || |  |  __/\n"
+              << "|_|  \\_\\|______||_____/         |_____/  \\__,_||_|   \\___|\n"
+              << "-----------------------------------------------------------\n";
     {
+      constexpr int total_width = 59;
+      constexpr int inner_width = total_width - 2;
+      const std::string port_msg = "Server listening on port: " + port;
+      const int pad1 = (inner_width - static_cast<int>(port_msg.size())) / 2;
+      const int pad2 = inner_width - pad1 - static_cast<int>(port_msg.size());
+      std::cout << "-" << std::string(pad1, ' ') << port_msg << std::string(pad2, ' ') << "-"
+                << "\n";
+      const std::string thread_msg = "Threads: " + threadnumbers;
+      const int pad3 = (inner_width - static_cast<int>(thread_msg.size())) / 2;
+      const int pad4 = inner_width - pad3 - static_cast<int>(thread_msg.size());
+      std::cout << "-" << std::string(pad3, ' ') << thread_msg << std::string(pad4, ' ') << "-"
+                << "\n";
     }
+    std::cout << "-----------------------------------------------------------\n";
+  }
 
-    Server::~Server() = default;
+  io_context io_;
+  ip::tcp::acceptor acceptor_;
+  std::unique_ptr<thread_pool> pool_;
+  std::vector<std::jthread> workers;
+  unsigned int numThreads = std::thread::hardware_concurrency();
+};
 
-    void Server::start() const
-    {
-        impl_->start();
-    }
+Server::Server(const uint16_t port) : impl_{std::make_unique<Impl>(port)} {}
 
-    void Server::stop() const
-    {
-        impl_->stop();
-    }
-}
+Server::~Server() = default;
+
+void Server::start() const { impl_->start(); }
+
+void Server::stop() const { impl_->stop(); }
+}  // namespace redsafe::apiserver

--- a/api-server/src/core/controller.cpp
+++ b/api-server/src/core/controller.cpp
@@ -1,385 +1,293 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 ******************************************************************************/
 
-#include <folly/container/F14Map.h>
+#include "controller.hpp"
+
 #include <folly/String.h>
+#include <folly/container/F14Map.h>
+
 #include <functional>
 
-#include "controller.hpp"
 #include "../service/EdgeService.hpp"
 #include "../service/IOSAPPService.hpp"
-#include "../service/UserService.hpp"
 #include "../service/TokenService.hpp"
+#include "../service/UserService.hpp"
 #include "../util/logger.hpp"
 // #include "../util/IOstream.hpp"
 #include "../util/response.hpp"
 
-namespace redsafe::apiserver
-{
-    Controller::Controller(http::request<http::string_body> req)
-        : req_(std::move(req))
-    {
-    }
+namespace redsafe::apiserver {
+Controller::Controller(http::request<http::string_body> req) : req_(std::move(req)) {}
 
-    response Controller::handle_request() const
-    {
-        static const folly::F14FastMap<
-            folly::StringPiece,
-            std::function<util::Result(const http::request<http::string_body>&)>> POST_map =
-        {
-            {"/edge/signup", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
-                    if (!body.contains("serial_number") || !body.contains("version"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_serial_number_or_version,
-                            json{}
-                        };
+response Controller::handle_request() const {
+  static const folly::F14FastMap<
+      folly::StringPiece, std::function<util::Result(const http::request<http::string_body>&)>>
+      POST_map = {
+          {"/edge/signup",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
+               if (!body.contains("serial_number") || !body.contains("version"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_serial_number_or_version, json{}};
 
-                    return service::edge::Register::start(
-                        body.value("version", std::string{}),
-                        body.value("serial_number", std::string{})
-                    );
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::edge::Register::start(body.value("version", std::string{}),
+                                                     body.value("serial_number", std::string{}));
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/user/signup", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
-                    if (!body.contains("email")     ||
-                        !body.contains("user_name") ||
-                        !body.contains("password"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_email_or_user_name_or_password,
-                            json{}
-                        };
+          {"/user/signup",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
+               if (!body.contains("email") || !body.contains("user_name") ||
+                   !body.contains("password"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_email_or_user_name_or_password,
+                                     json{}};
 
-                    return service::User::signup::run(
-                        body.value("email", std::string{}),
-                        body.value("user_name", std::string{}),
-                        body.value("password", std::string{}));
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::User::signup::run(body.value("email", std::string{}),
+                                                 body.value("user_name", std::string{}),
+                                                 body.value("password", std::string{}));
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/user/signin", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
+          {"/user/signin",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
 
-                    if (!body.contains("email") || !body.contains("password"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_email_or_password,
-                            json{}
-                        };
+               if (!body.contains("email") || !body.contains("password"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_email_or_password, json{}};
 
-                    return service::User::signin::run(
-                        body.value("email", std::string{}),
-                        body.value("password", std::string{}));
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::User::signin::run(body.value("email", std::string{}),
+                                                 body.value("password", std::string{}));
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/ios/signup", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
-                    if (!body.contains("user_id") || !body.contains("apns_token"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_user_id_or_apns_token,
-                            json{}
-                        };
+          {"/ios/signup",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
+               if (!body.contains("user_id") || !body.contains("apns_token"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_user_id_or_apns_token, json{}};
 
-                    return service::IOSAPP::IOSAPPService::start(
-                        body.value("ios_device_id", std::string{}),
-                        body.value("user_id", std::string{}),
-                        body.value("apns_token", std::string{}),
-                        body.value("device_name", std::string{})
-                    );
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::IOSAPP::IOSAPPService::start(
+                   body.value("ios_device_id", std::string{}), body.value("user_id", std::string{}),
+                   body.value("apns_token", std::string{}),
+                   body.value("device_name", std::string{}));
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/ios/bind", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
-                    if (!body.contains("serial_number"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_serial_number,
-                            json{}
-                        };
+          {"/ios/bind",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
+               if (!body.contains("serial_number"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_serial_number, json{}};
 
-                    const auto access_token = get_access_token(req);
+               const auto access_token = get_access_token(req);
 
-                    if (access_token.empty())
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Access_Token_invalid,
-                        };
+               if (access_token.empty())
+                 return util::Result{
+                     util::status_code::BadRequest,
+                     util::error_code::Access_Token_invalid,
+                 };
 
-                    return service::User::Binding::bind(
-                        body.value("serial_number", std::string{}),
-                        access_token);
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::User::Binding::bind(body.value("serial_number", std::string{}),
+                                                   access_token);
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/ios/unbind", [](const http::request<http::string_body>& req)
-            {
-                try
-                {
-                    const json body = json::parse(req.body());
-                    if (!body.contains("serial_number"))
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Missing_serial_number,
-                            json{}
-                        };
+          {"/ios/unbind",
+           [](const http::request<http::string_body>& req) {
+             try {
+               const json body = json::parse(req.body());
+               if (!body.contains("serial_number"))
+                 return util::Result{util::status_code::BadRequest,
+                                     util::error_code::Missing_serial_number, json{}};
 
-                    const auto access_token = get_access_token(req);
+               const auto access_token = get_access_token(req);
 
-                    if (access_token.empty())
-                        return util::Result{
-                            util::status_code::BadRequest,
-                            util::error_code::Access_Token_invalid,
-                        };
+               if (access_token.empty())
+                 return util::Result{
+                     util::status_code::BadRequest,
+                     util::error_code::Access_Token_invalid,
+                 };
 
-                    return service::User::Binding::unbind(
-                        body.value("serial_number", std::string{}),
-                        access_token);
-                }
-                catch ([[maybe_unused]] nlohmann::json::parse_error& e)
-                {
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Invalid_JSON,
-                        json{}
-                    };
-                }
-            }},
+               return service::User::Binding::unbind(body.value("serial_number", std::string{}),
+                                                     access_token);
+             } catch ([[maybe_unused]] nlohmann::json::parse_error& e) {
+               return util::Result{util::status_code::BadRequest, util::error_code::Invalid_JSON,
+                                   json{}};
+             }
+           }},
 
-            {"/auth/refresh", [](const http::request<http::string_body>& req)
-            {
-                const auto refresh_token = get_refresh_token(req);
+          {"/auth/refresh",
+           [](const http::request<http::string_body>& req) {
+             const auto refresh_token = get_refresh_token(req);
 
-                if (refresh_token.empty())
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Missing_refresh_token,
-                        json{}
-                    };
+             if (refresh_token.empty())
+               return util::Result{util::status_code::BadRequest,
+                                   util::error_code::Missing_refresh_token, json{}};
 
-                return service::token::CheckAndRefreshRefreshToken::run(refresh_token);
-            }},
+             return service::token::CheckAndRefreshRefreshToken::run(refresh_token);
+           }},
 
-            {"/auth/out", [](const http::request<http::string_body>& req)
-            {
-                const auto refresh_token = get_refresh_token(req);
+          {"/auth/out",
+           [](const http::request<http::string_body>& req) {
+             const auto refresh_token = get_refresh_token(req);
 
-                if (refresh_token.empty())
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Missing_refresh_token,
-                        json{}
-                    };
+             if (refresh_token.empty())
+               return util::Result{util::status_code::BadRequest,
+                                   util::error_code::Missing_refresh_token, json{}};
 
-                return service::token::RevokeRefreshToken::run(refresh_token);
-            }},
-        };
+             return service::token::RevokeRefreshToken::run(refresh_token);
+           }},
+      };
 
-        static const folly::F14FastMap<
-            folly::StringPiece,
-            std::function<util::Result(const http::request<http::string_body>&)>> GET_map =
-        {
-            {"/user/all", [this](const http::request<http::string_body>& req)
-            {
-                const auto access_token = get_access_token(req);
+  static const folly::F14FastMap<
+      folly::StringPiece, std::function<util::Result(const http::request<http::string_body>&)>>
+      GET_map = {
+          {"/user/all",
+           [this](const http::request<http::string_body>& req) {
+             const auto access_token = get_access_token(req);
 
-                if (access_token.empty())
-                    return util::Result{
-                        util::status_code::BadRequest,
-                        util::error_code::Access_Token_invalid,
-                    };
+             if (access_token.empty())
+               return util::Result{
+                   util::status_code::BadRequest,
+                   util::error_code::Access_Token_invalid,
+               };
 
-                return service::User::GetUserInformation::run(access_token);
-            }},
-        };
+             return service::User::GetUserInformation::run(access_token);
+           }},
+      };
 
-        util::Result ResponseBody;
+  util::Result ResponseBody;
 
-        if (req_.method() == http::verb::get)
-        {
-            if (const auto it = GET_map.find(folly::StringPiece{req_.target()}); it != GET_map.end())
-                ResponseBody = it->second(req_);
-            else
-                return make_response(
-                    static_cast<int>(util::status_code::NotFound),
-                    json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
-        }
-        else if (req_.method() == http::verb::post)
-        {
-            if (const auto it = POST_map.find(folly::StringPiece{req_.target()}); it != POST_map.end())
-                ResponseBody = it->second(req_);
-            else
-                return make_response(
-                    static_cast<int>(util::status_code::NotFound),
-                    json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
-        }
-        else
-            return make_response(
-                static_cast<int>(util::status_code::NotFound),
-                json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
+  if (req_.method() == http::verb::get) {
+    if (const auto it = GET_map.find(folly::StringPiece{req_.target()}); it != GET_map.end())
+      ResponseBody = it->second(req_);
+    else
+      return make_response(
+          static_cast<int>(util::status_code::NotFound),
+          json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
+  } else if (req_.method() == http::verb::post) {
+    if (const auto it = POST_map.find(folly::StringPiece{req_.target()}); it != POST_map.end())
+      ResponseBody = it->second(req_);
+    else
+      return make_response(
+          static_cast<int>(util::status_code::NotFound),
+          json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
+  } else
+    return make_response(
+        static_cast<int>(util::status_code::NotFound),
+        json{{"error_code", static_cast<int>(util::error_code::Unknown_endpoint)}});
 
-        /// 組合 response
-        ResponseBody.body["error_code"] = static_cast<int>(ResponseBody.ec);
-        if (ResponseBody.token.empty())
-            return make_response(static_cast<int>(ResponseBody.sc), ResponseBody.body);
-        return make_response(static_cast<int>(ResponseBody.sc), ResponseBody.body,
-                             "refresh_token=" + ResponseBody.token + // 明文 RT
-                             "; Path=/auth" // 只有 /auth/* 會帶
-                             "; Max-Age=2592000" // 30 天（秒）
-                             "; HttpOnly; Secure; SameSite=Strict");
-
-    }
-
-    response Controller::make_response(int status_code, const json& j)
-    {
-        response res{ static_cast<http::status>(status_code), 11 };
-        res.keep_alive(true);
-        res.set(http::field::server, "RED-Safe");
-        res.set(http::field::content_type, "application/json");
-        res.body() = j.dump();
-        res.prepare_payload();
-        return res;
-    }
-
-    response Controller::make_response(int status_code,
-                                       const json& j,
-                                       const std::string_view cookie)
-    {
-        response res{ static_cast<http::status>(status_code), 11 };
-        res.keep_alive(true);
-        res.set(http::field::server, "RED-Safe");
-        res.set(http::field::content_type, "application/json");
-        if (!cookie.empty())
-            res.set(http::field::set_cookie, cookie);
-        res.body() = j.dump();
-        res.prepare_payload();
-        return res;
-    }
-
-    std::string Controller::get_access_token(const http::request<http::string_body> &req)
-    {
-        std::string accesstoken;
-        if (req.base().count("Authorization"))
-        {
-            const auto authHeader = std::string(req.base().at("Authorization"));
-            if (constexpr std::string_view prefix = "Bearer ";
-                authHeader.size() > prefix.size() &&
-                authHeader.substr(0, prefix.size())
-                == prefix)
-            {
-                accesstoken = authHeader.substr(prefix.size());
-                const auto l = accesstoken.find_first_not_of(" \t\r\n");
-                const auto r = accesstoken.find_last_not_of(" \t\r\n");
-                if (l != std::string::npos)
-                    accesstoken = accesstoken.substr(l, r - l + 1);
-                else
-                    accesstoken.clear();
-            }
-        }
-        return accesstoken;
-    }
-
-    std::string Controller::get_refresh_token(const http::request<http::string_body> &req)
-    {
-        std::string refreshtoken;
-        if (req.base().count("Cookie"))
-        {
-            const auto cookieHeader = std::string(req.base().at("Cookie"));
-            static const std::string key = "refresh_token=";
-            if (auto pos = cookieHeader.find(key); pos != std::string::npos)
-            {
-                pos += key.size();
-                if (const auto end = cookieHeader.find(';', pos); end == std::string::npos)
-                    refreshtoken = cookieHeader.substr(pos);
-                else
-                    refreshtoken = cookieHeader.substr(pos, end - pos);
-                static constexpr char ws[] = " \t\r\n";
-                const auto l = refreshtoken.find_first_not_of(ws);
-                const auto r = refreshtoken.find_last_not_of(ws);
-                if (l != std::string::npos)
-                    refreshtoken = refreshtoken.substr(l, r - l + 1);
-                else
-                    refreshtoken.clear();
-            }
-        }
-        // 嚴格認證 Refresh Token 格式：64 字元的小寫十六進位
-        if (refreshtoken.size() != 64 ||
-            refreshtoken.find_first_not_of("0123456789abcdef")
-            != std::string::npos)
-            refreshtoken.clear();
-
-        return refreshtoken;
-    }
+  /// 組合 response
+  ResponseBody.body["error_code"] = static_cast<int>(ResponseBody.ec);
+  if (ResponseBody.token.empty())
+    return make_response(static_cast<int>(ResponseBody.sc), ResponseBody.body);
+  return make_response(static_cast<int>(ResponseBody.sc), ResponseBody.body,
+                       "refresh_token=" + ResponseBody.token +  // 明文 RT
+                           "; Path=/auth"                       // 只有 /auth/* 會帶
+                           "; Max-Age=2592000"                  // 30 天（秒）
+                           "; HttpOnly; Secure; SameSite=Strict");
 }
+
+response Controller::make_response(int status_code, const json& j) {
+  response res{static_cast<http::status>(status_code), 11};
+  res.keep_alive(true);
+  res.set(http::field::server, "RED-Safe");
+  res.set(http::field::content_type, "application/json");
+  res.body() = j.dump();
+  res.prepare_payload();
+  return res;
+}
+
+response Controller::make_response(int status_code, const json& j, const std::string_view cookie) {
+  response res{static_cast<http::status>(status_code), 11};
+  res.keep_alive(true);
+  res.set(http::field::server, "RED-Safe");
+  res.set(http::field::content_type, "application/json");
+  if (!cookie.empty()) res.set(http::field::set_cookie, cookie);
+  res.body() = j.dump();
+  res.prepare_payload();
+  return res;
+}
+
+std::string Controller::get_access_token(const http::request<http::string_body>& req) {
+  std::string accesstoken;
+  if (req.base().count("Authorization")) {
+    const auto authHeader = std::string(req.base().at("Authorization"));
+    if (constexpr std::string_view prefix = "Bearer ";
+        authHeader.size() > prefix.size() && authHeader.substr(0, prefix.size()) == prefix) {
+      accesstoken = authHeader.substr(prefix.size());
+      const auto l = accesstoken.find_first_not_of(" \t\r\n");
+      const auto r = accesstoken.find_last_not_of(" \t\r\n");
+      if (l != std::string::npos)
+        accesstoken = accesstoken.substr(l, r - l + 1);
+      else
+        accesstoken.clear();
+    }
+  }
+  return accesstoken;
+}
+
+std::string Controller::get_refresh_token(const http::request<http::string_body>& req) {
+  std::string refreshtoken;
+  if (req.base().count("Cookie")) {
+    const auto cookieHeader = std::string(req.base().at("Cookie"));
+    static const std::string key = "refresh_token=";
+    if (auto pos = cookieHeader.find(key); pos != std::string::npos) {
+      pos += key.size();
+      if (const auto end = cookieHeader.find(';', pos); end == std::string::npos)
+        refreshtoken = cookieHeader.substr(pos);
+      else
+        refreshtoken = cookieHeader.substr(pos, end - pos);
+      static constexpr char ws[] = " \t\r\n";
+      const auto l = refreshtoken.find_first_not_of(ws);
+      const auto r = refreshtoken.find_last_not_of(ws);
+      if (l != std::string::npos)
+        refreshtoken = refreshtoken.substr(l, r - l + 1);
+      else
+        refreshtoken.clear();
+    }
+  }
+  // 嚴格認證 Refresh Token 格式：64 字元的小寫十六進位
+  if (refreshtoken.size() != 64 ||
+      refreshtoken.find_first_not_of("0123456789abcdef") != std::string::npos)
+    refreshtoken.clear();
+
+  return refreshtoken;
+}
+}  // namespace redsafe::apiserver

--- a/api-server/src/core/controller.hpp
+++ b/api-server/src/core/controller.hpp
@@ -1,14 +1,14 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 ******************************************************************************/
 
@@ -17,61 +17,59 @@
 #include <boost/beast/http.hpp>
 #include <nlohmann/json.hpp>
 
-namespace redsafe::apiserver
-{
-    namespace beast = boost::beast;
-    namespace http = beast::http;
-    using json = nlohmann::json;
-    using response = http::response<http::string_body>;
+namespace redsafe::apiserver {
+namespace beast = boost::beast;
+namespace http = beast::http;
+using json = nlohmann::json;
+using response = http::response<http::string_body>;
 
-    class Controller
-    {
-    public:
-        explicit Controller(http::request<http::string_body> req);
+class Controller {
+ public:
+  explicit Controller(http::request<http::string_body> req);
 
-        [[nodiscard]] response handle_request() const;
+  [[nodiscard]] response handle_request() const;
 
-    private:
-    	/**
-		 * @brief 建立 http::request<http::string_body> 回應
-		 *
-		 * @param status_code HTTP 狀態碼
-		 * @param j           要回傳的 JSON 物件
-		 * @return response   Boost.Beast HTTP 回應
-		 */
-    	static response make_response(int status_code, const json& j);
+ private:
+  /**
+   * @brief 建立 http::request<http::string_body> 回應
+   *
+   * @param status_code HTTP 狀態碼
+   * @param j           要回傳的 JSON 物件
+   * @return response   Boost.Beast HTTP 回應
+   */
+  static response make_response(int status_code, const json& j);
 
-        /**
-		 * @brief 建立 http::request<http::string_body> 回應
-		 *
-		 * @param status_code HTTP 狀態碼
-		 * @param j           要回傳的 JSON 物件
-		 * @param cookie      若非空字串，將寫入 "Set-Cookie" 標頭
-		 * @return response   Boost.Beast HTTP 回應
-		 */
-        static response make_response(int status_code, const json& j, std::string_view cookie);
+  /**
+   * @brief 建立 http::request<http::string_body> 回應
+   *
+   * @param status_code HTTP 狀態碼
+   * @param j           要回傳的 JSON 物件
+   * @param cookie      若非空字串，將寫入 "Set-Cookie" 標頭
+   * @return response   Boost.Beast HTTP 回應
+   */
+  static response make_response(int status_code, const json& j, std::string_view cookie);
 
-		/**
-		* @brief 從 HTTP 請求的 Authorization 標頭中提取並驗證 Access Token
-		*
-		* 採用 "Bearer <token>" 格式
-		*
-		* @param req HTTP 請求物件
-		* @return 有效的 access token，或空字串
-		*/
-    	[[nodiscard]] static std::string get_access_token(const http::request<http::string_body>& req);
+  /**
+   * @brief 從 HTTP 請求的 Authorization 標頭中提取並驗證 Access Token
+   *
+   * 採用 "Bearer <token>" 格式
+   *
+   * @param req HTTP 請求物件
+   * @return 有效的 access token，或空字串
+   */
+  [[nodiscard]] static std::string get_access_token(const http::request<http::string_body>& req);
 
-    	/**
-		 * @brief 從 HTTP 請求的 Cookie 標頭中提取並驗證 Refresh Token
-		 *
-		 * 採用從 Cookie 字串中搜尋 "refresh_token="，回傳符合 64 字元小寫十六進位格式的 token，
-		 * 若格式不符或無法解析，回傳空字串。
-		 *
-		 * @param req HTTP 請求物件 (包含可能的 Cookie 標頭)
-		 * @return 有效的 refresh token，或空字串
-		 */
-    	[[nodiscard]] static std::string get_refresh_token(const http::request<http::string_body>& req);
+  /**
+   * @brief 從 HTTP 請求的 Cookie 標頭中提取並驗證 Refresh Token
+   *
+   * 採用從 Cookie 字串中搜尋 "refresh_token="，回傳符合 64 字元小寫十六進位格式的 token，
+   * 若格式不符或無法解析，回傳空字串。
+   *
+   * @param req HTTP 請求物件 (包含可能的 Cookie 標頭)
+   * @return 有效的 refresh token，或空字串
+   */
+  [[nodiscard]] static std::string get_refresh_token(const http::request<http::string_body>& req);
 
-        http::request<http::string_body> req_;
-    };
-}
+  http::request<http::string_body> req_;
+};
+}  // namespace redsafe::apiserver

--- a/api-server/src/core/session.cpp
+++ b/api-server/src/core/session.cpp
@@ -1,77 +1,66 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 ******************************************************************************/
+
+#include "session.hpp"
 
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/detached.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/beast/http.hpp>
 
-#include "session.hpp"
-#include "controller.hpp"
-#include "../util/logger.hpp"
 #include "../util/IOstream.hpp"
+#include "../util/logger.hpp"
+#include "controller.hpp"
 
-namespace beast      = boost::beast;
-namespace http       = beast::http;
-using     tcp        = boost::asio::ip::tcp;
+namespace beast = boost::beast;
+namespace http = beast::http;
+using tcp = boost::asio::ip::tcp;
 
-namespace redsafe::apiserver
-{
-    Session::Session(tcp::socket sock)
-        : socket_(std::move(sock))
-    {
-    }
+namespace redsafe::apiserver {
+Session::Session(tcp::socket sock) : socket_(std::move(sock)) {}
 
-    void Session::start()
-    {
-        boost::asio::co_spawn(socket_.get_executor(),
-                              [self = shared_from_this()]() { return self->run(); },
-                              boost::asio::detached);
-    }
-
-    boost::asio::awaitable<void> Session::run()
-    {
-        try
-        {
-            for (;;)
-            {
-                req_ = {};
-                buffer_.consume(buffer_.size());
-                co_await http::async_read(socket_, buffer_, req_, boost::asio::use_awaitable);
-                auto raw_req = req_;
-#ifndef NDEBUG
-                util::cout() << util::current_timestamp()
-                    << req_.base()["X-Real-IP"] << " " << req_.method() << " "
-                    << req_.target() << " " << req_.body() << '\n';
-                util::log(util::LogFile::access, util::Level::INFO)
-                    << req_.base()["X-Real-IP"] << " " << req_.method() << " "
-                    << req_.target() << " " << req_.body();
-#endif
-                auto response = std::make_shared<Controller>(req_)->handle_request();
-                co_await http::async_write(socket_, response, boost::asio::use_awaitable);
-            }
-        }
-        catch (const std::exception& e)
-        {
-#ifndef NDEBUG
-            // util::cout() << e.what() << '\n';
-#endif
-            util::cout() << util::current_timestamp()
-                << "nginx disconnection: "
-                << socket_.remote_endpoint().address().to_string() << ':'
-                << socket_.remote_endpoint().port() << '\n';
-            socket_.close();
-        }
-    }
+void Session::start() {
+  boost::asio::co_spawn(
+      socket_.get_executor(), [self = shared_from_this()]() { return self->run(); },
+      boost::asio::detached);
 }
+
+boost::asio::awaitable<void> Session::run() {
+  try {
+    for (;;) {
+      req_ = {};
+      buffer_.consume(buffer_.size());
+      co_await http::async_read(socket_, buffer_, req_, boost::asio::use_awaitable);
+      auto raw_req = req_;
+#ifndef NDEBUG
+      util::cout() << util::current_timestamp() << req_.base()["X-Real-IP"] << " " << req_.method()
+                   << " " << req_.target() << " " << req_.body() << '\n';
+      util::log(util::LogFile::access, util::Level::INFO)
+          << req_.base()["X-Real-IP"] << " " << req_.method() << " " << req_.target() << " "
+          << req_.body();
+#endif
+      auto response = std::make_shared<Controller>(req_)->handle_request();
+      co_await http::async_write(socket_, response, boost::asio::use_awaitable);
+    }
+  } catch (const std::exception& e) {
+#ifndef NDEBUG
+    // util::cout() << e.what() << '\n';
+#endif
+    util::cout() << util::current_timestamp()
+                 << "nginx disconnection: " << socket_.remote_endpoint().address().to_string()
+                 << ':' << socket_.remote_endpoint().port() << '\n';
+    socket_.close();
+  }
+}
+}  // namespace redsafe::apiserver

--- a/api-server/src/core/session.hpp
+++ b/api-server/src/core/session.hpp
@@ -1,36 +1,35 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 ******************************************************************************/
 
 #pragma once
 
-#include <memory>
+#include <boost/asio/awaitable.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
-#include <boost/asio/awaitable.hpp>
+#include <memory>
 
-namespace redsafe::apiserver
-{
-    class Session : public std::enable_shared_from_this<Session>
-    {
-    public:
-        explicit Session(boost::asio::ip::tcp::socket sock);
-        void start();
-    private:
-        boost::asio::awaitable<void> run();
-        boost::asio::ip::tcp::socket                                    socket_;
-        boost::beast::flat_buffer                                       buffer_;
-        boost::beast::http::request<boost::beast::http::string_body>    req_;
-    };
-}
+namespace redsafe::apiserver {
+class Session : public std::enable_shared_from_this<Session> {
+ public:
+  explicit Session(boost::asio::ip::tcp::socket sock);
+  void start();
+
+ private:
+  boost::asio::awaitable<void> run();
+  boost::asio::ip::tcp::socket socket_;
+  boost::beast::flat_buffer buffer_;
+  boost::beast::http::request<boost::beast::http::string_body> req_;
+};
+}  // namespace redsafe::apiserver

--- a/api-server/src/model/sql/SqlConnectionManager.hpp
+++ b/api-server/src/model/sql/SqlConnectionManager.hpp
@@ -1,165 +1,120 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
 #ifndef REDSAFE_SQLCONNECTIONMANAGER_HPP
 #define REDSAFE_SQLCONNECTIONMANAGER_HPP
 
-#include <pqxx/pqxx>
 #include <memory>
-#include <string>
+#include <pqxx/pqxx>
 #include <stdexcept>
+#include <string>
 
 #include "../../../config.hpp"
 
-namespace redsafe::apiserver::model::sql
-{
-    class ConnectionManager
-    {
-    public:
-        static void initConnection(const std::string& conn_str)
-        {
-            if (!conn_)
-            {
-                conn_ = std::make_unique<pqxx::connection>(conn_str);
-                if (!conn_->is_open())
-                    throw std::runtime_error("DB connection failed: " + conn_str);
-                SQLinit(*conn_);
-            }
-        }
+namespace redsafe::apiserver::model::sql {
+class ConnectionManager {
+ public:
+  static void initConnection(const std::string& conn_str) {
+    if (!conn_) {
+      conn_ = std::make_unique<pqxx::connection>(conn_str);
+      if (!conn_->is_open()) throw std::runtime_error("DB connection failed: " + conn_str);
+      SQLinit(*conn_);
+    }
+  }
 
-        static pqxx::connection& connection()
-        {
-            if (!conn_)
-                initConnection(SQL_CONNECTION_STR);
-            return *conn_;
-        }
-    private:
-        static inline thread_local std::unique_ptr<pqxx::connection> conn_{nullptr};
+  static pqxx::connection& connection() {
+    if (!conn_) initConnection(SQL_CONNECTION_STR);
+    return *conn_;
+  }
 
-        static void SQLinit(pqxx::connection& conn)
-        {
-            try
-            {
-                conn.prepare(
-                    "register_edge",
-                    "INSERT INTO edge_devices "
-                    "(edge_serial_number, version) "
-                    "VALUES ($1, $2) "
-                    "ON CONFLICT (edge_serial_number) DO NOTHING"
-                );
-                conn.prepare(
-                    "register_user",
-                    "INSERT INTO users "
-                    "(email, user_name, user_password_hash) "
-                    "VALUES ($1, $2, $3) "
-                    "ON CONFLICT DO NOTHING"
-                );
-                conn.prepare(
-                    "find_user_id",
-                    "SELECT user_id FROM users WHERE email = $1"
-                );
-                conn.prepare(
-                    "find_user_name_email",
-                    "SELECT user_name FROM users WHERE email = $1"
-                );
-                conn.prepare(
-                    "find_user_name_userid",
-                    "SELECT user_name FROM users WHERE user_id = $1"
-                );
-                conn.prepare(
-                    "find_email",
-                    "SELECT email FROM users WHERE user_id = $1"
-                );
-                conn.prepare(
-                    "register_ios_device",
-                    "INSERT INTO ios_devices "
-                    "(ios_device_id, user_id, apns_token, device_name, last_seen_at) "
-                    "VALUES (COALESCE(NULLIF($1,'')::uuid, gen_random_uuid()), $2, $3, $4, NOW()) "
-                    "ON CONFLICT (ios_device_id) DO UPDATE "
-                    "SET user_id      = EXCLUDED.user_id, "
-                    "    apns_token   = EXCLUDED.apns_token, "
-                    "    device_name  = EXCLUDED.device_name, "
-                    "    last_seen_at = NOW()"
-                );
-                conn.prepare(
-                    "find_ios_device_id",
-                    "SELECT ios_device_id FROM ios_devices WHERE apns_token = $1"
-                );
-                conn.prepare(
-                    "bind_edge_user",
-                    "INSERT INTO edge_users "
-                    "(edge_serial_number, user_id) "
-                    "VALUES ($1, $2) "
-                    "ON CONFLICT DO NOTHING"
-                );
-                conn.prepare(
-                    "unbind_edge_user",
-                    "DELETE FROM edge_users "
-                    "WHERE edge_serial_number = $1 "
-                    "AND   user_id      = $2"
-                );
-                conn.prepare(
-                    "find_user_pwdhash",
-                    "SELECT user_password_hash "
-                    "FROM users "
-                    "WHERE email = $1"
-                );
-                conn.prepare(
-                    "find_user_edges",
-                    "SELECT edge_serial_number "
-                    "FROM edge_users "
-                    "WHERE user_id = $1"
-                );
-                conn.prepare(
-                    "reg_refretoken",
-                    "INSERT INTO auth "
-                    "(refresh_token_hash, user_id, expires_at) "
-                    "VALUES ($1, $2, NOW() + INTERVAL '30 days')"
-                );
-                conn.prepare(
-                    "chk_refretoken",
-                    "WITH upd AS ( "
-                    "    UPDATE auth "
-                    "    SET    expires_at = NOW() + INTERVAL '30 days' "
-                    "    WHERE  refresh_token_hash = $1 "
-                    "      AND  revoked = FALSE "
-                    "      AND  expires_at > NOW() "
-                    "    RETURNING user_id "
-                    "), rev AS ( "
-                    "    UPDATE auth "
-                    "    SET    revoked = TRUE "
-                    "    WHERE  refresh_token_hash = $1 "
-                    "      AND  revoked = FALSE "
-                    "      AND  expires_at <= NOW() "
-                    ") "
-                    "SELECT user_id FROM upd"
-                );
-                conn.prepare(
-                    "revoke_refretoken",
-                    "UPDATE auth "
-                    "SET revoked = TRUE "
-                    "WHERE refresh_token_hash = $1"
-                );
+ private:
+  static inline thread_local std::unique_ptr<pqxx::connection> conn_{nullptr};
 
-            }
-            catch (const pqxx::sql_error &e)
-            {
-                if (e.sqlstate() != "42P05")
-                    throw;
-            }
-        }
-    };
-}
+  static void SQLinit(pqxx::connection& conn) {
+    try {
+      conn.prepare("register_edge",
+                   "INSERT INTO edge_devices "
+                   "(edge_serial_number, version) "
+                   "VALUES ($1, $2) "
+                   "ON CONFLICT (edge_serial_number) DO NOTHING");
+      conn.prepare("register_user",
+                   "INSERT INTO users "
+                   "(email, user_name, user_password_hash) "
+                   "VALUES ($1, $2, $3) "
+                   "ON CONFLICT DO NOTHING");
+      conn.prepare("find_user_id", "SELECT user_id FROM users WHERE email = $1");
+      conn.prepare("find_user_name_email", "SELECT user_name FROM users WHERE email = $1");
+      conn.prepare("find_user_name_userid", "SELECT user_name FROM users WHERE user_id = $1");
+      conn.prepare("find_email", "SELECT email FROM users WHERE user_id = $1");
+      conn.prepare("register_ios_device",
+                   "INSERT INTO ios_devices "
+                   "(ios_device_id, user_id, apns_token, device_name, last_seen_at) "
+                   "VALUES (COALESCE(NULLIF($1,'')::uuid, gen_random_uuid()), $2, $3, $4, NOW()) "
+                   "ON CONFLICT (ios_device_id) DO UPDATE "
+                   "SET user_id      = EXCLUDED.user_id, "
+                   "    apns_token   = EXCLUDED.apns_token, "
+                   "    device_name  = EXCLUDED.device_name, "
+                   "    last_seen_at = NOW()");
+      conn.prepare("find_ios_device_id",
+                   "SELECT ios_device_id FROM ios_devices WHERE apns_token = $1");
+      conn.prepare("bind_edge_user",
+                   "INSERT INTO edge_users "
+                   "(edge_serial_number, user_id) "
+                   "VALUES ($1, $2) "
+                   "ON CONFLICT DO NOTHING");
+      conn.prepare("unbind_edge_user",
+                   "DELETE FROM edge_users "
+                   "WHERE edge_serial_number = $1 "
+                   "AND   user_id      = $2");
+      conn.prepare("find_user_pwdhash",
+                   "SELECT user_password_hash "
+                   "FROM users "
+                   "WHERE email = $1");
+      conn.prepare("find_user_edges",
+                   "SELECT edge_serial_number "
+                   "FROM edge_users "
+                   "WHERE user_id = $1");
+      conn.prepare("reg_refretoken",
+                   "INSERT INTO auth "
+                   "(refresh_token_hash, user_id, expires_at) "
+                   "VALUES ($1, $2, NOW() + INTERVAL '30 days')");
+      conn.prepare("chk_refretoken",
+                   "WITH upd AS ( "
+                   "    UPDATE auth "
+                   "    SET    expires_at = NOW() + INTERVAL '30 days' "
+                   "    WHERE  refresh_token_hash = $1 "
+                   "      AND  revoked = FALSE "
+                   "      AND  expires_at > NOW() "
+                   "    RETURNING user_id "
+                   "), rev AS ( "
+                   "    UPDATE auth "
+                   "    SET    revoked = TRUE "
+                   "    WHERE  refresh_token_hash = $1 "
+                   "      AND  revoked = FALSE "
+                   "      AND  expires_at <= NOW() "
+                   ") "
+                   "SELECT user_id FROM upd");
+      conn.prepare("revoke_refretoken",
+                   "UPDATE auth "
+                   "SET revoked = TRUE "
+                   "WHERE refresh_token_hash = $1");
+
+    } catch (const pqxx::sql_error& e) {
+      if (e.sqlstate() != "42P05") throw;
+    }
+  }
+};
+}  // namespace redsafe::apiserver::model::sql
 
 #endif

--- a/api-server/src/model/sql/read.cpp
+++ b/api-server/src/model/sql/read.cpp
@@ -16,216 +16,130 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #define REDSAFE_FINDER_MODEL_CPP
 
 #include "read.hpp"
+
 #include "../../util/IOstream.hpp"
 #include "../../util/logger.hpp"
 
-namespace redsafe::apiserver::model::sql::fin
-{
-    std::string UserIDFinder::start(std::string_view email)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_user_id"),
-                pqxx::params{email}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr() << "UserIDFinder::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserIDFinder::start failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::string UserNameFinder::start_by_email(std::string_view email)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_user_name_email"),
-                pqxx::params{email}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "UserNameFinder::start_by_email failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserNameFinder::start_by_email failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::string UserNameFinder::start_by_user_id(std::string_view user_id)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_user_name_userid"),
-                pqxx::params{user_id}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "UserNameFinder::start_by_user_id failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserNameFinder::start_by_user_id failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::string UserEmailFinder::start(std::string_view user_id)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_email"),
-                pqxx::params{user_id}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "UserNameFinder::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserNameFinder::start failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::string IOSDeviceIDFinder::start(std::string_view apns_token)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_ios_device_id"),
-                pqxx::params{apns_token}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "IOSDeviceFinder::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "IOSDeviceFinder::start failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::string UserPasswordHashFinder::start(std::string_view email)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_user_pwdhash"),
-                pqxx::params{email}
-            );
-            if (r.empty())
-                return std::string{};
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "UserPasswordHashFinder::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserPasswordHashFinder::start failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
-
-    std::vector<std::string> UserEdgeListFinder::start(std::string_view user_id)
-    {
-        std::vector<std::string> edges;
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("find_user_edges"),
-                pqxx::params{user_id}
-            );
-
-            edges.reserve(r.size());
-            for (auto row : r)
-                edges.emplace_back(row[0].as<std::string>());
-            return edges;
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "UserEdgeListFinder::FetchEdges failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserEdgeListFinder::FetchEdges failed: "
-                    << e.what();
-            return edges;
-        }
-    }
-
-    std::string RefreshTokenRefresher::start(std::string_view refresh_token_hash)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const pqxx::result r = tx.exec(
-                pqxx::prepped("chk_refretoken"),
-                pqxx::params{refresh_token_hash}
-            );
-            if (r.empty())
-            {
-                tx.commit();
-                return std::string{};
-            }
-            tx.commit();
-            return r[0][0].as<std::string>();
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "RefreshTokenRefresher::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "RefreshTokenRefresher::start failed: "
-                    << e.what();
-            return std::string{};
-        }
-    }
+namespace redsafe::apiserver::model::sql::fin {
+std::string UserIDFinder::start(std::string_view email) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_user_id"), pqxx::params{email});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "UserIDFinder::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserIDFinder::start failed: " << e.what();
+    return std::string{};
+  }
 }
+
+std::string UserNameFinder::start_by_email(std::string_view email) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_user_name_email"), pqxx::params{email});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "UserNameFinder::start_by_email failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserNameFinder::start_by_email failed: " << e.what();
+    return std::string{};
+  }
+}
+
+std::string UserNameFinder::start_by_user_id(std::string_view user_id) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_user_name_userid"), pqxx::params{user_id});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "UserNameFinder::start_by_user_id failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserNameFinder::start_by_user_id failed: " << e.what();
+    return std::string{};
+  }
+}
+
+std::string UserEmailFinder::start(std::string_view user_id) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_email"), pqxx::params{user_id});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "UserNameFinder::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserNameFinder::start failed: " << e.what();
+    return std::string{};
+  }
+}
+
+std::string IOSDeviceIDFinder::start(std::string_view apns_token) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_ios_device_id"), pqxx::params{apns_token});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "IOSDeviceFinder::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "IOSDeviceFinder::start failed: " << e.what();
+    return std::string{};
+  }
+}
+
+std::string UserPasswordHashFinder::start(std::string_view email) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_user_pwdhash"), pqxx::params{email});
+    if (r.empty()) return std::string{};
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "UserPasswordHashFinder::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserPasswordHashFinder::start failed: " << e.what();
+    return std::string{};
+  }
+}
+
+std::vector<std::string> UserEdgeListFinder::start(std::string_view user_id) {
+  std::vector<std::string> edges;
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r = tx.exec(pqxx::prepped("find_user_edges"), pqxx::params{user_id});
+
+    edges.reserve(r.size());
+    for (auto row : r) edges.emplace_back(row[0].as<std::string>());
+    return edges;
+  } catch (const std::exception& e) {
+    util::cerr() << "UserEdgeListFinder::FetchEdges failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserEdgeListFinder::FetchEdges failed: " << e.what();
+    return edges;
+  }
+}
+
+std::string RefreshTokenRefresher::start(std::string_view refresh_token_hash) {
+  try {
+    pqxx::work tx{connection()};
+    const pqxx::result r =
+        tx.exec(pqxx::prepped("chk_refretoken"), pqxx::params{refresh_token_hash});
+    if (r.empty()) {
+      tx.commit();
+      return std::string{};
+    }
+    tx.commit();
+    return r[0][0].as<std::string>();
+  } catch (const std::exception& e) {
+    util::cerr() << "RefreshTokenRefresher::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "RefreshTokenRefresher::start failed: " << e.what();
+    return std::string{};
+  }
+}
+}  // namespace redsafe::apiserver::model::sql::fin
 
 #endif

--- a/api-server/src/model/sql/read.hpp
+++ b/api-server/src/model/sql/read.hpp
@@ -17,75 +17,66 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 
 #include "SqlConnectionManager.hpp"
 
-namespace redsafe::apiserver::model::sql::fin
-{
-    // 取得 User ID
-    class UserIDFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳 User ID 否則空字串
-        [[nodiscard]] static std::string start(std::string_view email);
-    };
+namespace redsafe::apiserver::model::sql::fin {
+// 取得 User ID
+class UserIDFinder : public ConnectionManager {
+ public:
+  // 成功回傳 User ID 否則空字串
+  [[nodiscard]] static std::string start(std::string_view email);
+};
 
-    // 取得 User Name
-    class UserNameFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳 User Name 否則空字串
-        [[nodiscard]] static std::string start_by_email(std::string_view email);
+// 取得 User Name
+class UserNameFinder : public ConnectionManager {
+ public:
+  // 成功回傳 User Name 否則空字串
+  [[nodiscard]] static std::string start_by_email(std::string_view email);
 
-        // 成功回傳 User Name 否則空字串
-        [[nodiscard]] static std::string start_by_user_id(std::string_view user_id);
-    };
+  // 成功回傳 User Name 否則空字串
+  [[nodiscard]] static std::string start_by_user_id(std::string_view user_id);
+};
 
-    // 取得 Email
-    class UserEmailFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳 Email 否則空字串
-        [[nodiscard]] static std::string start(std::string_view user_id);
-    };
+// 取得 Email
+class UserEmailFinder : public ConnectionManager {
+ public:
+  // 成功回傳 Email 否則空字串
+  [[nodiscard]] static std::string start(std::string_view user_id);
+};
 
-    // 取得 iOS device ID
-    class IOSDeviceIDFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳iOS device ID 否則空字串
-        [[nodiscard]] static std::string start(std::string_view apns_token);
-    };
+// 取得 iOS device ID
+class IOSDeviceIDFinder : public ConnectionManager {
+ public:
+  // 成功回傳iOS device ID 否則空字串
+  [[nodiscard]] static std::string start(std::string_view apns_token);
+};
 
-    // 依 email 取得密碼雜湊
-    class UserPasswordHashFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳password hash 否則空字串
-        [[nodiscard]] static std::string start(std::string_view email);
-    };
+// 依 email 取得密碼雜湊
+class UserPasswordHashFinder : public ConnectionManager {
+ public:
+  // 成功回傳password hash 否則空字串
+  [[nodiscard]] static std::string start(std::string_view email);
+};
 
-    // 依 user_id 取回該帳號所有 Edge 序號
-    class UserEdgeListFinder : public ConnectionManager
-    {
-    public:
-        // 成功回傳Edge 序號 ALL 否則空字串
-        [[nodiscard]] static std::vector<std::string> start(std::string_view user_id);
-    };
+// 依 user_id 取回該帳號所有 Edge 序號
+class UserEdgeListFinder : public ConnectionManager {
+ public:
+  // 成功回傳Edge 序號 ALL 否則空字串
+  [[nodiscard]] static std::vector<std::string> start(std::string_view user_id);
+};
 
-    // 檢查並刷新 Refresh Token（若仍有效則續期 +30 天，回傳 user_id）
-    class RefreshTokenRefresher : public ConnectionManager
-    {
-    public:
-        /**
-         * @brief 驗證 refresh_token_hash 是否有效
-         *        若有效：更新 expires_at = NOW() + INTERVAL '30 days' 並回傳 user_id
-         *        若過期：自動 revoked = TRUE，回傳空字串
-         *
-         * @param refresh_token_hash Token 雜湊
-         * @return std::string 有效則為 user_id，否則為空字串
-         */
-        [[nodiscard]] static std::string start(std::string_view refresh_token_hash);
-    };
+// 檢查並刷新 Refresh Token（若仍有效則續期 +30 天，回傳 user_id）
+class RefreshTokenRefresher : public ConnectionManager {
+ public:
+  /**
+   * @brief 驗證 refresh_token_hash 是否有效
+   *        若有效：更新 expires_at = NOW() + INTERVAL '30 days' 並回傳 user_id
+   *        若過期：自動 revoked = TRUE，回傳空字串
+   *
+   * @param refresh_token_hash Token 雜湊
+   * @return std::string 有效則為 user_id，否則為空字串
+   */
+  [[nodiscard]] static std::string start(std::string_view refresh_token_hash);
+};
 
-
-}
+}  // namespace redsafe::apiserver::model::sql::fin
 
 #endif

--- a/api-server/src/model/sql/write.cpp
+++ b/api-server/src/model/sql/write.cpp
@@ -16,208 +16,125 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #define REDSAFE_REGISTRAR_MODEL_CPP
 
 #include "write.hpp"
+
 #include "../../util/IOstream.hpp"
 #include "../../util/logger.hpp"
 
-namespace redsafe::apiserver::model::sql::reg
-{
-    int EdgeDeviceRegistrar::start(
-        std::string_view serial_number,
-        std::string_view version
-    )
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const auto r = tx.exec(
-                pqxx::prepped("register_edge"),
-                pqxx::params{serial_number, version}
-            );
-            if (r.affected_rows() == 0)
-                return 1;
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception &e)
-        {
-            util::cerr()
-                    << "EdgeDeviceRegistrar::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "EdgeDeviceRegistrar::start failed: "
-                    << e.what();
-            return 2;
-        }
-    }
-
-    int UserRegistrar::start(
-        std::string_view email,
-        std::string_view user_name,
-        std::string_view password_hash
-    )
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const auto r = tx.exec(
-                pqxx::prepped("register_user"),
-                pqxx::params{email, user_name, password_hash}
-            );
-            if (r.affected_rows() == 0)
-                return 1;
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception &e)
-        {
-            util::cerr()
-                    << "UserRegistrar::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "UserRegistrar::start failed: "
-                    << e.what();
-            return 2;
-        }
-    }
-
-    int IOSDeviceRegistrar::start(
-        std::string_view ios_device_id,
-        std::string_view user_id,
-        std::string_view apns_token,
-        std::string_view device_name
-    )
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            pqxx::params p;
-            if (ios_device_id.empty())
-                p.append("");
-            else
-                p.append(ios_device_id);
-            p.append(user_id);
-            p.append(apns_token);
-            p.append(device_name);
-            tx.exec(pqxx::prepped("register_ios_device"), p);
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception &e)
-        {
-            util::cerr()
-                    << "IOSDeviceRegistrar::start failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "IOSDeviceRegistrar::start failed: "
-                    << e.what();
-            return 1;
-        }
-    }
-
-    int EdgeIOSBindingRegistrar::bind(
-        std::string_view edge_serial_number,
-        std::string_view user_id
-    )
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const auto r = tx.exec(
-                pqxx::prepped("bind_edge_user"),
-                pqxx::params{edge_serial_number, user_id}
-            );
-            if (r.affected_rows() == 0)
-                return 1;
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                    << "EdgeIOSBindingRegistrar::bind failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "EdgeIOSBindingRegistrar::bind failed: "
-                    << e.what();
-            return 2;
-        }
-    }
-
-    int EdgeIOSBindingRegistrar::unbind(
-        std::string_view edge_serial_number,
-        std::string_view user_id
-    )
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            tx.exec(
-                pqxx::prepped("unbind_edge_user"),
-                pqxx::params{edge_serial_number, user_id}
-            );
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr() << "EdgeIOSBindingRegistrar::unbind failed: "
-                    << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                    << "EdgeIOSBindingRegistrar::unbind failed: "
-                    << e.what();
-            return 1;
-        }
-    }
-
-    int RefreshTokenRegistrar::start(std::string_view refresh_token_hash, std::string_view user_id)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const auto r = tx.exec(
-                pqxx::prepped("reg_refretoken"),
-                pqxx::params{refresh_token_hash, user_id}
-            );
-            if (r.affected_rows() == 0)
-                return 1;                       // 已存在或未插入
-            tx.commit();
-            return 0;                           // 成功
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                << "RefreshTokenRegistrar::start failed: "
-                << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                << "RefreshTokenRegistrar::start failed: "
-                << e.what();
-            return 2;                           // SQL 錯誤
-        }
-    }
-
-    int RefreshTokenRevoke::start(std::string_view refresh_token_hash)
-    {
-        try
-        {
-            pqxx::work tx{connection()};
-            const auto r = tx.exec(
-                pqxx::prepped("revoke_refretoken"),
-                pqxx::params{refresh_token_hash}
-            );
-            tx.commit();
-            return 0;
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr()
-                << "RefreshTokenRevoke::start failed: "
-                << e.what() << '\n';
-            util::log(util::LogFile::server, util::Level::ERROR)
-                << "RefreshTokenRevoke::start failed: "
-                << e.what();
-            return 1;                           // SQL 錯誤
-        }
-    }
+namespace redsafe::apiserver::model::sql::reg {
+int EdgeDeviceRegistrar::start(std::string_view serial_number, std::string_view version) {
+  try {
+    pqxx::work tx{connection()};
+    const auto r = tx.exec(pqxx::prepped("register_edge"), pqxx::params{serial_number, version});
+    if (r.affected_rows() == 0) return 1;
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "EdgeDeviceRegistrar::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "EdgeDeviceRegistrar::start failed: " << e.what();
+    return 2;
+  }
 }
+
+int UserRegistrar::start(std::string_view email, std::string_view user_name,
+                         std::string_view password_hash) {
+  try {
+    pqxx::work tx{connection()};
+    const auto r =
+        tx.exec(pqxx::prepped("register_user"), pqxx::params{email, user_name, password_hash});
+    if (r.affected_rows() == 0) return 1;
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "UserRegistrar::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "UserRegistrar::start failed: " << e.what();
+    return 2;
+  }
+}
+
+int IOSDeviceRegistrar::start(std::string_view ios_device_id, std::string_view user_id,
+                              std::string_view apns_token, std::string_view device_name) {
+  try {
+    pqxx::work tx{connection()};
+    pqxx::params p;
+    if (ios_device_id.empty())
+      p.append("");
+    else
+      p.append(ios_device_id);
+    p.append(user_id);
+    p.append(apns_token);
+    p.append(device_name);
+    tx.exec(pqxx::prepped("register_ios_device"), p);
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "IOSDeviceRegistrar::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "IOSDeviceRegistrar::start failed: " << e.what();
+    return 1;
+  }
+}
+
+int EdgeIOSBindingRegistrar::bind(std::string_view edge_serial_number, std::string_view user_id) {
+  try {
+    pqxx::work tx{connection()};
+    const auto r =
+        tx.exec(pqxx::prepped("bind_edge_user"), pqxx::params{edge_serial_number, user_id});
+    if (r.affected_rows() == 0) return 1;
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "EdgeIOSBindingRegistrar::bind failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "EdgeIOSBindingRegistrar::bind failed: " << e.what();
+    return 2;
+  }
+}
+
+int EdgeIOSBindingRegistrar::unbind(std::string_view edge_serial_number, std::string_view user_id) {
+  try {
+    pqxx::work tx{connection()};
+    tx.exec(pqxx::prepped("unbind_edge_user"), pqxx::params{edge_serial_number, user_id});
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "EdgeIOSBindingRegistrar::unbind failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "EdgeIOSBindingRegistrar::unbind failed: " << e.what();
+    return 1;
+  }
+}
+
+int RefreshTokenRegistrar::start(std::string_view refresh_token_hash, std::string_view user_id) {
+  try {
+    pqxx::work tx{connection()};
+    const auto r =
+        tx.exec(pqxx::prepped("reg_refretoken"), pqxx::params{refresh_token_hash, user_id});
+    if (r.affected_rows() == 0) return 1;  // 已存在或未插入
+    tx.commit();
+    return 0;  // 成功
+  } catch (const std::exception& e) {
+    util::cerr() << "RefreshTokenRegistrar::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "RefreshTokenRegistrar::start failed: " << e.what();
+    return 2;  // SQL 錯誤
+  }
+}
+
+int RefreshTokenRevoke::start(std::string_view refresh_token_hash) {
+  try {
+    pqxx::work tx{connection()};
+    const auto r = tx.exec(pqxx::prepped("revoke_refretoken"), pqxx::params{refresh_token_hash});
+    tx.commit();
+    return 0;
+  } catch (const std::exception& e) {
+    util::cerr() << "RefreshTokenRevoke::start failed: " << e.what() << '\n';
+    util::log(util::LogFile::server, util::Level::ERROR)
+        << "RefreshTokenRevoke::start failed: " << e.what();
+    return 1;  // SQL 錯誤
+  }
+}
+}  // namespace redsafe::apiserver::model::sql::reg
 
 #endif

--- a/api-server/src/model/sql/write.hpp
+++ b/api-server/src/model/sql/write.hpp
@@ -17,73 +17,53 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 
 #include "SqlConnectionManager.hpp"
 
-namespace redsafe::apiserver::model::sql::reg
-{
-    // 邊緣裝置註冊
-    class EdgeDeviceRegistrar : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:serial_number註冊過 2:SQL錯誤
-        [[nodiscard]] static int start(
-            std::string_view serial_number,
-            std::string_view version
-        );
-    };
+namespace redsafe::apiserver::model::sql::reg {
+// 邊緣裝置註冊
+class EdgeDeviceRegistrar : public ConnectionManager {
+ public:
+  // 0:成功 1:serial_number註冊過 2:SQL錯誤
+  [[nodiscard]] static int start(std::string_view serial_number, std::string_view version);
+};
 
-    // 使用者註冊
-    class UserRegistrar : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:email被註冊過 2:SQL錯誤
-        [[nodiscard]] static int start(
-            std::string_view email,
-            std::string_view user_name,
-            std::string_view password_hash
-        );
-    };
+// 使用者註冊
+class UserRegistrar : public ConnectionManager {
+ public:
+  // 0:成功 1:email被註冊過 2:SQL錯誤
+  [[nodiscard]] static int start(std::string_view email, std::string_view user_name,
+                                 std::string_view password_hash);
+};
 
-    // IOS裝置註冊
-    class IOSDeviceRegistrar : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:SQL錯誤
-        [[nodiscard]] static int start(
-            std::string_view ios_device_id,
-            std::string_view user_id,
-            std::string_view apns_token,
-            std::string_view device_name
-        );
-    };
+// IOS裝置註冊
+class IOSDeviceRegistrar : public ConnectionManager {
+ public:
+  // 0:成功 1:SQL錯誤
+  [[nodiscard]] static int start(std::string_view ios_device_id, std::string_view user_id,
+                                 std::string_view apns_token, std::string_view device_name);
+};
 
-    // Edge ↔ iOS 裝置綁定
-    class EdgeIOSBindingRegistrar : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:已經綁定 2:SQL錯誤
-        [[nodiscard]] static int bind   (std::string_view edge_serial_number, std::string_view user_id);
+// Edge ↔ iOS 裝置綁定
+class EdgeIOSBindingRegistrar : public ConnectionManager {
+ public:
+  // 0:成功 1:已經綁定 2:SQL錯誤
+  [[nodiscard]] static int bind(std::string_view edge_serial_number, std::string_view user_id);
 
-        // 0:成功 1:SQL錯誤
-        [[nodiscard]] static int unbind (std::string_view edge_serial_number, std::string_view user_id);
-    };
+  // 0:成功 1:SQL錯誤
+  [[nodiscard]] static int unbind(std::string_view edge_serial_number, std::string_view user_id);
+};
 
-    // Refresh Token 註冊
-    class RefreshTokenRegistrar : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:refresh_token_hash 已存在 2:SQL錯誤
-        [[nodiscard]] static int start(
-            std::string_view refresh_token_hash,
-            std::string_view user_id
-        );
-    };
+// Refresh Token 註冊
+class RefreshTokenRegistrar : public ConnectionManager {
+ public:
+  // 0:成功 1:refresh_token_hash 已存在 2:SQL錯誤
+  [[nodiscard]] static int start(std::string_view refresh_token_hash, std::string_view user_id);
+};
 
-    // Refresh Token 註銷
-    class RefreshTokenRevoke : public ConnectionManager
-    {
-    public:
-        // 0:成功 1:SQL錯誤
-        [[nodiscard]] static int start(std::string_view refresh_token_hash);
-    };
-}
+// Refresh Token 註銷
+class RefreshTokenRevoke : public ConnectionManager {
+ public:
+  // 0:成功 1:SQL錯誤
+  [[nodiscard]] static int start(std::string_view refresh_token_hash);
+};
+}  // namespace redsafe::apiserver::model::sql::reg
 
 #endif

--- a/api-server/src/model/validator/ParameterValidation.hpp
+++ b/api-server/src/model/validator/ParameterValidation.hpp
@@ -18,52 +18,35 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #include <regex>
 #include <string>
 
-namespace redsafe::apiserver::model::validator
-{
-    // true : 合法
-    inline bool is_vaild_serial_number(const std::string_view serial_number)
-    {
-        return std::regex_match(
-            serial_number.begin(),
-            serial_number.end(),
-            std::regex{R"(^RED-[0-9A-F]{8}$)"});
-    }
-
-    // true : 合法
-    inline bool is_vaild_apns(const std::string_view apns)
-    {
-        return std::regex_match(
-            apns.begin(),
-            apns.end(),
-            std::regex{R"(^[0-9a-f]{64}$)"});
-    }
-
-    // true : 合法
-    inline bool is_vaild_email(const std::string_view email)
-    {
-        return std::regex_match(
-            email.begin(),
-            email.end(),
-            std::regex{R"(^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$)"});
-    }
-
-    // trun : 合法
-    inline bool is_vaild_password(const std::string_view password)
-    {
-        return std::regex_match(
-            password.begin(),
-            password.end(),
-            std::regex{R"(^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$)"});
-    }
-
-    // true : 合法
-    inline bool is_vaild_user_name(const std::string_view user_name)
-    {
-        return std::regex_match(
-            user_name.begin(),
-            user_name.end(),
-            std::regex{R"(^[A-Za-z0-9._\-]{1,16}$)"});
-    }
+namespace redsafe::apiserver::model::validator {
+// true : 合法
+inline bool is_vaild_serial_number(const std::string_view serial_number) {
+  return std::regex_match(serial_number.begin(), serial_number.end(),
+                          std::regex{R"(^RED-[0-9A-F]{8}$)"});
 }
+
+// true : 合法
+inline bool is_vaild_apns(const std::string_view apns) {
+  return std::regex_match(apns.begin(), apns.end(), std::regex{R"(^[0-9a-f]{64}$)"});
+}
+
+// true : 合法
+inline bool is_vaild_email(const std::string_view email) {
+  return std::regex_match(email.begin(), email.end(),
+                          std::regex{R"(^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$)"});
+}
+
+// trun : 合法
+inline bool is_vaild_password(const std::string_view password) {
+  return std::regex_match(password.begin(), password.end(),
+                          std::regex{R"(^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$)"});
+}
+
+// true : 合法
+inline bool is_vaild_user_name(const std::string_view user_name) {
+  return std::regex_match(user_name.begin(), user_name.end(),
+                          std::regex{R"(^[A-Za-z0-9._\-]{1,16}$)"});
+}
+}  // namespace redsafe::apiserver::model::validator
 
 #endif

--- a/api-server/src/service/EdgeService.cpp
+++ b/api-server/src/service/EdgeService.cpp
@@ -1,60 +1,47 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
 #ifndef REDSAFE_EDGE_SERVICE_CPP
 #define REDSAFE_EDGE_SERVICE_CPP
 
+#include "EdgeService.hpp"
+
 #include <nlohmann/json.hpp>
 
-#include "EdgeService.hpp"
 #include "../model/sql/write.hpp"
 #include "../model/validator/ParameterValidation.hpp"
 
-namespace redsafe::apiserver::service::edge
-{
-    util::Result Register::start(const std::string& version, const std::string& serial_number)
-    {
-        using namespace model::validator;
-        using namespace model::sql::reg;
-        using json = nlohmann::json;
+namespace redsafe::apiserver::service::edge {
+util::Result Register::start(const std::string& version, const std::string& serial_number) {
+  using namespace model::validator;
+  using namespace model::sql::reg;
+  using json = nlohmann::json;
 
-        if (!is_vaild_serial_number(serial_number))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_serialnumber_format,
-                json{}
-            };
+  if (!is_vaild_serial_number(serial_number))
+    return util::Result{util::status_code::BadRequest,
+                        util::error_code::Invalid_serialnumber_format, json{}};
 
-        if (const auto a = EdgeDeviceRegistrar::start(serial_number, version); a == 1)
-            return util::Result{
-                util::status_code::Conflict,
-                util::error_code::Edge_device_already_registered,
-                json{}
-            };
-        else if (a == 2)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
+  if (const auto a = EdgeDeviceRegistrar::start(serial_number, version); a == 1)
+    return util::Result{util::status_code::Conflict,
+                        util::error_code::Edge_device_already_registered, json{}};
+  else if (a == 2)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
 
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{{"serial_number", serial_number}}
-        };
-    }
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"serial_number", serial_number}}};
 }
+}  // namespace redsafe::apiserver::service::edge
 
 #endif

--- a/api-server/src/service/EdgeService.hpp
+++ b/api-server/src/service/EdgeService.hpp
@@ -1,14 +1,14 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
@@ -17,15 +17,12 @@
 
 #include "../util/response.hpp"
 
-namespace redsafe::apiserver::service::edge
-{
-    class Register
-    {
-    public:
-        [[nodiscard]] static util::Result start(
-            const std::string& version,
-            const std::string& serial_number);
-    };
-}
+namespace redsafe::apiserver::service::edge {
+class Register {
+ public:
+  [[nodiscard]] static util::Result start(const std::string& version,
+                                          const std::string& serial_number);
+};
+}  // namespace redsafe::apiserver::service::edge
 
 #endif

--- a/api-server/src/service/IOSAPPService.cpp
+++ b/api-server/src/service/IOSAPPService.cpp
@@ -15,70 +15,44 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_IOSAPP_SERVICE_CPP
 #define REDSAFE_IOSAPP_SERVICE_CPP
 
+#include "IOSAPPService.hpp"
+
 #include <nlohmann/json.hpp>
 
-#include "IOSAPPService.hpp"
-#include "../util/response.hpp"
-#include "../model/sql/write.hpp"
 #include "../model/sql/read.hpp"
+#include "../model/sql/write.hpp"
 #include "../model/validator/ParameterValidation.hpp"
+#include "../util/response.hpp"
 
-namespace redsafe::apiserver::service::IOSAPP
-{
-    util::Result IOSAPPService::start(
-        const std::string &ios_device_id,
-        const std::string &user_id,
-        const std::string &apns_token,
-        const std::string &device_name
-    )
-    {
-        using namespace model::validator;
-        using namespace model::sql::reg;
-        using namespace model::sql::fin;
-        using json = nlohmann::json;
+namespace redsafe::apiserver::service::IOSAPP {
+util::Result IOSAPPService::start(const std::string &ios_device_id, const std::string &user_id,
+                                  const std::string &apns_token, const std::string &device_name) {
+  using namespace model::validator;
+  using namespace model::sql::reg;
+  using namespace model::sql::fin;
+  using json = nlohmann::json;
 
-        if (!is_vaild_apns(apns_token))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_apnstoken_format,
-                json{}
-            };
+  if (!is_vaild_apns(apns_token))
+    return util::Result{util::status_code::BadRequest, util::error_code::Invalid_apnstoken_format,
+                        json{}};
 
-        if (IOSDeviceRegistrar::start(ios_device_id, user_id, apns_token, device_name) == 1)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
+  if (IOSDeviceRegistrar::start(ios_device_id, user_id, apns_token, device_name) == 1)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
 
-        if (!ios_device_id.empty())
-            return util::Result{
-                util::status_code::Success,
-                util::error_code::Success,
-                json{
-                    {"user_id", user_id},
-                    {"apns_token", apns_token},
-                    {"ios_device_id", ios_device_id}
-                }
-            };
+  if (!ios_device_id.empty())
+    return util::Result{
+        util::status_code::Success, util::error_code::Success,
+        json{{"user_id", user_id}, {"apns_token", apns_token}, {"ios_device_id", ios_device_id}}};
 
-        if (auto ios_device_id_ = IOSDeviceIDFinder::start(apns_token); ios_device_id_.empty())
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-        else
-            return util::Result{
-                util::status_code::Success,
-                util::error_code::Success,
-                json{
-                    {"user_id", user_id},
-                    {"apns_token", apns_token},
-                    {"ios_device_id", ios_device_id_}
-                }
-            };
-    }
+  if (auto ios_device_id_ = IOSDeviceIDFinder::start(apns_token); ios_device_id_.empty())
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+  else
+    return util::Result{
+        util::status_code::Success, util::error_code::Success,
+        json{{"user_id", user_id}, {"apns_token", apns_token}, {"ios_device_id", ios_device_id_}}};
 }
+}  // namespace redsafe::apiserver::service::IOSAPP
 
 #endif

--- a/api-server/src/service/IOSAPPService.hpp
+++ b/api-server/src/service/IOSAPPService.hpp
@@ -17,17 +17,13 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 
 #include "../util/response.hpp"
 
-namespace redsafe::apiserver::service::IOSAPP
-{
-    class IOSAPPService
-    {
-    public:
-        [[nodiscard]] static util::Result start(
-            const std::string &ios_device_id,
-            const std::string &user_id,
-            const std::string &apns_token,
-            const std::string &device_name);
-    };
-}
+namespace redsafe::apiserver::service::IOSAPP {
+class IOSAPPService {
+ public:
+  [[nodiscard]] static util::Result start(const std::string &ios_device_id,
+                                          const std::string &user_id, const std::string &apns_token,
+                                          const std::string &device_name);
+};
+}  // namespace redsafe::apiserver::service::IOSAPP
 
 #endif

--- a/api-server/src/service/TokenService.cpp
+++ b/api-server/src/service/TokenService.cpp
@@ -15,211 +15,137 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_TOKEN_SERVICE_CPP
 #define REDSAFE_TOKEN_SERVICE_CPP
 
+#include "TokenService.hpp"
+
 #include <nlohmann/json.hpp>
 #include <utility>
 
-#include "TokenService.hpp"
-#include "../model/sql/write.hpp"
 #include "../model/sql/read.hpp"
+#include "../model/sql/write.hpp"
 #include "../util/IOstream.hpp"
-#include "../util/response.hpp"
 #include "../util/logger.hpp"
+#include "../util/response.hpp"
 
-namespace redsafe::apiserver::service::token
-{
-    using json = nlohmann::json;
+namespace redsafe::apiserver::service::token {
+using json = nlohmann::json;
 
-    CreateAccessToken::CreateAccessToken(const std::string_view user_id)
-        : user_id(user_id)
-    {
-    }
+CreateAccessToken::CreateAccessToken(const std::string_view user_id) : user_id(user_id) {}
 
-    int CreateAccessToken::start()
-    {
-        try
-        {
-            token = jwt::create()
+int CreateAccessToken::start() {
+  try {
+    token = jwt::create()
                 .set_issuer("RED-Safe")
                 .set_subject(util::AESManager::instance().encrypt(user_id))
                 .set_issued_at(std::chrono::system_clock::now())
-                .set_expires_at(
-                    std::chrono::system_clock::now() +
-                    std::chrono::seconds{600})
-                .sign(jwt::algorithm::hs256{
-                    util::SecretManager::instance().getSecret()});
-        }
-        catch (const std::exception& e)
-        {
-            util::cerr() << e.what() << std::endl;
-            util::log(util::LogFile::server, util::Level::ERROR) << e.what();
-            return 1;
-        }
-        return 0;
-    }
-
-    std::string CreateAccessToken::getAccessToken() const
-    {
-        return token;
-    }
-
-    std::string CreateAccessToken::getErrorMessage() const
-    {
-        return errorMessage;
-    }
-
-    DecodeAccessToken::DecodeAccessToken(std::string tokenStr)
-        : tokenValue(std::move(tokenStr))
-    {
-    }
-
-    int DecodeAccessToken::start()
-    {
-        try
-        {
-            // Decode the JWT token string (without immediate verification)
-            const auto decoded = jwt::decode(tokenValue);
-
-            // 先檢查是否含有 exp 欄位並檢查過期時間
-            if (decoded.has_expires_at())
-            {
-                if (const auto expTime = decoded.get_expires_at();
-                    std::chrono::system_clock::now() > expTime)
-                {
-                    errorMessage = "Token 已過期";
-                    return 1;
-                }
-            }
-
-            // 驗證 HS256 簽章與 issuer
-            jwt::verify()
-                .allow_algorithm(jwt::algorithm::hs256{
-                    util::SecretManager::instance().getSecret()})
-                .with_issuer("RED-Safe")
-                .verify(decoded);
-
-            // 解析 payload 中的 sub 欄位作為 user_id
-            if (decoded.has_payload_claim("sub"))
-            {
-                payloadUserId = util::AESManager::instance().decrypt(
-                    decoded.get_payload_claim("sub").as_string());
-                return 0;
-            }
-            errorMessage = "Token 中缺少 sub 欄位";
-            return 2;
-        }
-        catch (const std::exception& e)
-        {
-            // Capture any decoding or verification errors
-            errorMessage = e.what();
-            std::cerr << e.what() << std::endl;
-            if (errorMessage == "invalid signature")
-                return 3;
-            if (errorMessage == "invalid token supplied")
-                return 4;
-            return 5;
-        }
-    }
-
-    std::string DecodeAccessToken::getUserId() const
-    {
-        return payloadUserId;
-    }
-
-    std::string DecodeAccessToken::getErrorMessage() const
-    {
-        return errorMessage;
-    }
-
-    CreateRefreshToken::CreateRefreshToken(const std::string_view user_id)
-        : user_id(user_id)
-    {
-    }
-
-    int CreateRefreshToken::start()
-    {
-        try
-        {
-            token = util::generateRandomHex(32);
-            WriteToSQL();
-        }
-        catch (const std::exception& e)
-        {
-            errorMessage = e.what();
-            return 1;
-        }
-        return 0;
-    }
-
-    std::string CreateRefreshToken::getRefreshToken() const
-    {
-        return token;
-    }
-
-    std::string CreateRefreshToken::getErrorMessage() const
-    {
-        return errorMessage;
-    }
-
-    void CreateRefreshToken::WriteToSQL() const
-    {
-        if (model::sql::reg::RefreshTokenRegistrar::start(
-            util::SHA256_HEX(token), user_id) != 0)
-            throw std::runtime_error("Failed to reg refresh token in sql");
-    }
-
-    util::Result CheckAndRefreshRefreshToken::run(const std::string& refreshtoken)
-    {
-        const std::string user_id =
-            model::sql::fin::RefreshTokenRefresher::start(
-                util::SHA256_HEX(refreshtoken));
-
-        if (user_id.empty())
-        {
-            return util::Result{
-                util::status_code::Unauthorized,
-                util::error_code::Refresh_Token_Expired,
-                json{}
-            };
-        }
-
-        // 3. 產生新的 Access Token
-        CreateAccessToken at(user_id);
-        if (at.start() != 0)
-        {
-            util::cerr() << at.getErrorMessage();
-            util::log(util::LogFile::server, util::Level::ERROR)
-                << at.getErrorMessage();
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-        }
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{{"access_token", at.getAccessToken()}}
-        };
-    }
-
-    util::Result RevokeRefreshToken::run(const std::string &refreshtoken)
-    {
-
-        if (model::sql::reg::RefreshTokenRevoke::start(
-            util::SHA256_HEX(refreshtoken)) == 1)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{}
-        };
-    }
+                .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{600})
+                .sign(jwt::algorithm::hs256{util::SecretManager::instance().getSecret()});
+  } catch (const std::exception& e) {
+    util::cerr() << e.what() << std::endl;
+    util::log(util::LogFile::server, util::Level::ERROR) << e.what();
+    return 1;
+  }
+  return 0;
 }
+
+std::string CreateAccessToken::getAccessToken() const { return token; }
+
+std::string CreateAccessToken::getErrorMessage() const { return errorMessage; }
+
+DecodeAccessToken::DecodeAccessToken(std::string tokenStr) : tokenValue(std::move(tokenStr)) {}
+
+int DecodeAccessToken::start() {
+  try {
+    // Decode the JWT token string (without immediate verification)
+    const auto decoded = jwt::decode(tokenValue);
+
+    // 先檢查是否含有 exp 欄位並檢查過期時間
+    if (decoded.has_expires_at()) {
+      if (const auto expTime = decoded.get_expires_at();
+          std::chrono::system_clock::now() > expTime) {
+        errorMessage = "Token 已過期";
+        return 1;
+      }
+    }
+
+    // 驗證 HS256 簽章與 issuer
+    jwt::verify()
+        .allow_algorithm(jwt::algorithm::hs256{util::SecretManager::instance().getSecret()})
+        .with_issuer("RED-Safe")
+        .verify(decoded);
+
+    // 解析 payload 中的 sub 欄位作為 user_id
+    if (decoded.has_payload_claim("sub")) {
+      payloadUserId =
+          util::AESManager::instance().decrypt(decoded.get_payload_claim("sub").as_string());
+      return 0;
+    }
+    errorMessage = "Token 中缺少 sub 欄位";
+    return 2;
+  } catch (const std::exception& e) {
+    // Capture any decoding or verification errors
+    errorMessage = e.what();
+    std::cerr << e.what() << std::endl;
+    if (errorMessage == "invalid signature") return 3;
+    if (errorMessage == "invalid token supplied") return 4;
+    return 5;
+  }
+}
+
+std::string DecodeAccessToken::getUserId() const { return payloadUserId; }
+
+std::string DecodeAccessToken::getErrorMessage() const { return errorMessage; }
+
+CreateRefreshToken::CreateRefreshToken(const std::string_view user_id) : user_id(user_id) {}
+
+int CreateRefreshToken::start() {
+  try {
+    token = util::generateRandomHex(32);
+    WriteToSQL();
+  } catch (const std::exception& e) {
+    errorMessage = e.what();
+    return 1;
+  }
+  return 0;
+}
+
+std::string CreateRefreshToken::getRefreshToken() const { return token; }
+
+std::string CreateRefreshToken::getErrorMessage() const { return errorMessage; }
+
+void CreateRefreshToken::WriteToSQL() const {
+  if (model::sql::reg::RefreshTokenRegistrar::start(util::SHA256_HEX(token), user_id) != 0)
+    throw std::runtime_error("Failed to reg refresh token in sql");
+}
+
+util::Result CheckAndRefreshRefreshToken::run(const std::string& refreshtoken) {
+  const std::string user_id =
+      model::sql::fin::RefreshTokenRefresher::start(util::SHA256_HEX(refreshtoken));
+
+  if (user_id.empty()) {
+    return util::Result{util::status_code::Unauthorized, util::error_code::Refresh_Token_Expired,
+                        json{}};
+  }
+
+  // 3. 產生新的 Access Token
+  CreateAccessToken at(user_id);
+  if (at.start() != 0) {
+    util::cerr() << at.getErrorMessage();
+    util::log(util::LogFile::server, util::Level::ERROR) << at.getErrorMessage();
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+  }
+
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"access_token", at.getAccessToken()}}};
+}
+
+util::Result RevokeRefreshToken::run(const std::string& refreshtoken) {
+  if (model::sql::reg::RefreshTokenRevoke::start(util::SHA256_HEX(refreshtoken)) == 1)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  return util::Result{util::status_code::Success, util::error_code::Success, json{}};
+}
+}  // namespace redsafe::apiserver::service::token
 
 #endif

--- a/api-server/src/service/TokenService.hpp
+++ b/api-server/src/service/TokenService.hpp
@@ -15,168 +15,163 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_TOKEN_SERVICE_HPP
 #define REDSAFE_TOKEN_SERVICE_HPP
 
+#include "../lib/jwt-cpp/jwt.h"
 #include "../util/crypto.hpp"
 #include "../util/response.hpp"
-#include "../lib/jwt-cpp/jwt.h"
 
-namespace redsafe::apiserver::service::token
-{
-    /**
-     * @brief 創建 Access Token（JWT）
-     */
-    class CreateAccessToken
-    {
-    public:
-        /**
-         * @brief 創建 Access_Token 使用 JWT
-         *
-         * @param user_id 使用者 user_id
-         */
-        explicit CreateAccessToken(std::string_view user_id);
+namespace redsafe::apiserver::service::token {
+/**
+ * @brief 創建 Access Token（JWT）
+ */
+class CreateAccessToken {
+ public:
+  /**
+   * @brief 創建 Access_Token 使用 JWT
+   *
+   * @param user_id 使用者 user_id
+   */
+  explicit CreateAccessToken(std::string_view user_id);
 
-        /**
-         * @brief 執行解碼與驗證
-         * @return 0: 驗證通過，並將 AccessToken 存到 token
-         * @return 1: 例外錯誤
-         */
-        [[nodiscard]] int start();
+  /**
+   * @brief 執行解碼與驗證
+   * @return 0: 驗證通過，並將 AccessToken 存到 token
+   * @return 1: 例外錯誤
+   */
+  [[nodiscard]] int start();
 
-        /**
-         * @brief 取得編碼後的 AccessToken
-         * @return 編碼後的 AccessToken，若未通過驗證則為空字串
-         */
-        [[nodiscard]] std::string getAccessToken() const;
+  /**
+   * @brief 取得編碼後的 AccessToken
+   * @return 編碼後的 AccessToken，若未通過驗證則為空字串
+   */
+  [[nodiscard]] std::string getAccessToken() const;
 
-        /**
-         * @brief 取得驗證失敗時的錯誤訊息
-         * @return 失敗時的錯誤描述
-         */
-        [[nodiscard]] std::string getErrorMessage() const;
+  /**
+   * @brief 取得驗證失敗時的錯誤訊息
+   * @return 失敗時的錯誤描述
+   */
+  [[nodiscard]] std::string getErrorMessage() const;
 
-    private:
-        std::string user_id;
-        std::string token;
-        std::string errorMessage;
-    };
+ private:
+  std::string user_id;
+  std::string token;
+  std::string errorMessage;
+};
 
-    /**
-     * @brief 解碼並驗證 Access Token（JWT）
-     */
-    class DecodeAccessToken
-    {
-    public:
-        /**
-         * @brief 建構子，接收要解碼的 JWT 字串
-         * @param tokenStr 要解碼的 Access Token
-         */
-        explicit DecodeAccessToken(std::string tokenStr);
+/**
+ * @brief 解碼並驗證 Access Token（JWT）
+ */
+class DecodeAccessToken {
+ public:
+  /**
+   * @brief 建構子，接收要解碼的 JWT 字串
+   * @param tokenStr 要解碼的 Access Token
+   */
+  explicit DecodeAccessToken(std::string tokenStr);
 
-        /**
-         * @brief 執行解碼與驗證
-         * @return 0: 驗證通過，並將 user_id 存到 payloadUserId
-         * @return 1: 表示驗證失敗 過時
-         * @return 2: Token 中缺少 sub 欄位
-         * @return 3: invalid signature 簽名錯誤
-         * @return 4: 例外錯誤
-         */
-        [[nodiscard]] int start();
+  /**
+   * @brief 執行解碼與驗證
+   * @return 0: 驗證通過，並將 user_id 存到 payloadUserId
+   * @return 1: 表示驗證失敗 過時
+   * @return 2: Token 中缺少 sub 欄位
+   * @return 3: invalid signature 簽名錯誤
+   * @return 4: 例外錯誤
+   */
+  [[nodiscard]] int start();
 
-        /**
-         * @brief 取得解碼後的 user_id (sub claim)
-         * @return std::string 解碼後的 user_id，若未通過驗證則為空字串
-         */
-        [[nodiscard]] std::string getUserId() const;
+  /**
+   * @brief 取得解碼後的 user_id (sub claim)
+   * @return std::string 解碼後的 user_id，若未通過驗證則為空字串
+   */
+  [[nodiscard]] std::string getUserId() const;
 
-        /**
-         * @brief 取得驗證失敗時的錯誤訊息
-         * @return std::string 解驗證失敗時的錯誤描述
-         */
-        [[nodiscard]] std::string getErrorMessage() const;
+  /**
+   * @brief 取得驗證失敗時的錯誤訊息
+   * @return std::string 解驗證失敗時的錯誤描述
+   */
+  [[nodiscard]] std::string getErrorMessage() const;
 
-    private:
-        std::string tokenValue;
-        std::string payloadUserId;
-        std::string errorMessage;
-    };
+ private:
+  std::string tokenValue;
+  std::string payloadUserId;
+  std::string errorMessage;
+};
 
-    /**
-     * @brief 創建 Refresh Token
-     */
-    class CreateRefreshToken
-    {
-    public:
-        /**
-         * @brief 創建 Refresh_Token
-         *
-         * @param user_id 使用者 user_id
-         */
-        explicit CreateRefreshToken(std::string_view user_id);
+/**
+ * @brief 創建 Refresh Token
+ */
+class CreateRefreshToken {
+ public:
+  /**
+   * @brief 創建 Refresh_Token
+   *
+   * @param user_id 使用者 user_id
+   */
+  explicit CreateRefreshToken(std::string_view user_id);
 
-        /**
-         * @brief 執行解碼與驗證
-         * @return 0: 創建成功，並將 RefreshToken 存到 token
-         * @return 1: 錯誤
-         */
-        [[nodiscard]] int start();
+  /**
+   * @brief 執行解碼與驗證
+   * @return 0: 創建成功，並將 RefreshToken 存到 token
+   * @return 1: 錯誤
+   */
+  [[nodiscard]] int start();
 
-        /**
-        * @brief 取得編碼後的 RefreshToken
-        * @return 編碼後的 RefreshToken
-        */
-        [[nodiscard]] std::string getRefreshToken() const;
+  /**
+   * @brief 取得編碼後的 RefreshToken
+   * @return 編碼後的 RefreshToken
+   */
+  [[nodiscard]] std::string getRefreshToken() const;
 
-        /**
-         * @brief 如果 `start()` 遇到例外，這裡會有錯誤訊息
-         * @return 失敗時的錯誤描述；產生成功則為空字串
-         */
-        [[nodiscard]] std::string getErrorMessage() const;
-    private:
-        /**
-         * @brief 將 Refresh 寫入資料庫
-         */
-        void WriteToSQL() const;
-        std::string user_id;
-        std::string token;
-        std::string errorMessage;
-    };
+  /**
+   * @brief 如果 `start()` 遇到例外，這裡會有錯誤訊息
+   * @return 失敗時的錯誤描述；產生成功則為空字串
+   */
+  [[nodiscard]] std::string getErrorMessage() const;
 
-    /**
-     * @brief check Refresh Token 是否過期或被註銷
-     */
-    class CheckAndRefreshRefreshToken
-    {
-    public:
-        /**
-         * @brief 執行解碼與驗證
-         * @return util::Result
-         */
-        [[nodiscard]] static util::Result run(const std::string& refreshtoken);
+ private:
+  /**
+   * @brief 將 Refresh 寫入資料庫
+   */
+  void WriteToSQL() const;
+  std::string user_id;
+  std::string token;
+  std::string errorMessage;
+};
 
-        /// 禁止拷貝和移動
-        CheckAndRefreshRefreshToken(const CheckAndRefreshRefreshToken&)             = delete;
-        CheckAndRefreshRefreshToken(CheckAndRefreshRefreshToken&&)                  = delete;
-        CheckAndRefreshRefreshToken& operator=(const CheckAndRefreshRefreshToken&)  = delete;
-        CheckAndRefreshRefreshToken& operator=(CheckAndRefreshRefreshToken&&)       = delete;
-    };
+/**
+ * @brief check Refresh Token 是否過期或被註銷
+ */
+class CheckAndRefreshRefreshToken {
+ public:
+  /**
+   * @brief 執行解碼與驗證
+   * @return util::Result
+   */
+  [[nodiscard]] static util::Result run(const std::string& refreshtoken);
 
-    /**
-     * @brief Refresh Token 註銷
-     */
-    class RevokeRefreshToken
-    {
-    public:
-        /**
-         * @brief 執行註銷
-         * @return util::Result
-         */
-        [[nodiscard]] static util::Result run(const std::string& refreshtoken);
+  /// 禁止拷貝和移動
+  CheckAndRefreshRefreshToken(const CheckAndRefreshRefreshToken&) = delete;
+  CheckAndRefreshRefreshToken(CheckAndRefreshRefreshToken&&) = delete;
+  CheckAndRefreshRefreshToken& operator=(const CheckAndRefreshRefreshToken&) = delete;
+  CheckAndRefreshRefreshToken& operator=(CheckAndRefreshRefreshToken&&) = delete;
+};
 
-        /// 禁止拷貝和移動
-        RevokeRefreshToken(const RevokeRefreshToken&)             = delete;
-        RevokeRefreshToken(RevokeRefreshToken&&)                  = delete;
-        RevokeRefreshToken& operator=(const RevokeRefreshToken&)  = delete;
-        RevokeRefreshToken& operator=(RevokeRefreshToken&&)       = delete;
-    };
-}
+/**
+ * @brief Refresh Token 註銷
+ */
+class RevokeRefreshToken {
+ public:
+  /**
+   * @brief 執行註銷
+   * @return util::Result
+   */
+  [[nodiscard]] static util::Result run(const std::string& refreshtoken);
+
+  /// 禁止拷貝和移動
+  RevokeRefreshToken(const RevokeRefreshToken&) = delete;
+  RevokeRefreshToken(RevokeRefreshToken&&) = delete;
+  RevokeRefreshToken& operator=(const RevokeRefreshToken&) = delete;
+  RevokeRefreshToken& operator=(RevokeRefreshToken&&) = delete;
+};
+}  // namespace redsafe::apiserver::service::token
 
 #endif

--- a/api-server/src/service/UserService.cpp
+++ b/api-server/src/service/UserService.cpp
@@ -15,363 +15,217 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_USER_SERVICE_CPP
 #define REDSAFE_USER_SERVICE_CPP
 
+#include "UserService.hpp"
+
 #include <nlohmann/json.hpp>
 
-#include "UserService.hpp"
-#include "TokenService.hpp"
 #include "../model/sql/read.hpp"
 #include "../model/sql/write.hpp"
 #include "../model/validator/ParameterValidation.hpp"
 #include "../util/IOstream.hpp"
 #include "../util/logger.hpp"
+#include "TokenService.hpp"
 
-namespace redsafe::apiserver::service::User
-{
-    using namespace model::validator;
-    using namespace model::sql::reg;
-    using namespace model::sql::fin;
-    using json = nlohmann::json;
+namespace redsafe::apiserver::service::User {
+using namespace model::validator;
+using namespace model::sql::reg;
+using namespace model::sql::fin;
+using json = nlohmann::json;
 
-    util::Result signin::run(
-        const std::string &email,
-        const std::string &password)
-    {
-        if (!is_vaild_email(email))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_email_format,
-                json{}
-            };
+util::Result signin::run(const std::string &email, const std::string &password) {
+  if (!is_vaild_email(email))
+    return util::Result{util::status_code::BadRequest, util::error_code::Invalid_email_format,
+                        json{}};
 
-        const auto password_hash = UserPasswordHashFinder::start(email);
-        if (password_hash.empty())
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Email_or_Password_Error,
-                json{}
-            };
+  const auto password_hash = UserPasswordHashFinder::start(email);
+  if (password_hash.empty())
+    return util::Result{util::status_code::BadRequest, util::error_code::Email_or_Password_Error,
+                        json{}};
 
-        if (!util::VerifyHASH(password_hash, password))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Email_or_Password_Error,
-                json{}
-            };
+  if (!util::VerifyHASH(password_hash, password))
+    return util::Result{util::status_code::BadRequest, util::error_code::Email_or_Password_Error,
+                        json{}};
 
-        const auto user_name = UserNameFinder::start_by_email(email);
-        if (user_name.empty())
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
+  const auto user_name = UserNameFinder::start_by_email(email);
+  if (user_name.empty())
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
 
-        const auto user_id = UserIDFinder::start(email);
-        if (user_id.empty())
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
+  const auto user_id = UserIDFinder::start(email);
+  if (user_id.empty())
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
 
-        token::CreateAccessToken AT(user_id);
-        if (AT.start() == 1)
-        {
-            util::cerr() << AT.getErrorMessage();
-            util::log(util::LogFile::server, util::Level::ERROR) << AT.getErrorMessage();
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-        }
+  token::CreateAccessToken AT(user_id);
+  if (AT.start() == 1) {
+    util::cerr() << AT.getErrorMessage();
+    util::log(util::LogFile::server, util::Level::ERROR) << AT.getErrorMessage();
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+  }
 
-        token::CreateRefreshToken RT(user_id);
-        if (RT.start() == 1)
-        {
-            util::cerr() << RT.getErrorMessage();
-            util::log(util::LogFile::server, util::Level::ERROR) << RT.getErrorMessage();
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-        }
+  token::CreateRefreshToken RT(user_id);
+  if (RT.start() == 1) {
+    util::cerr() << RT.getErrorMessage();
+    util::log(util::LogFile::server, util::Level::ERROR) << RT.getErrorMessage();
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+  }
 
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{
-                {"user_name", user_name},
-                {"access_token", AT.getAccessToken()}
-            },
-            RT.getRefreshToken()
-        };
-    }
-
-    util::Result signup::run(
-            const std::string& email,
-            const std::string& user_name,
-            const std::string& password)
-    {
-       if (!is_vaild_email(email))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_email_format,
-                json{}
-            };
-
-        // if (!is_vaild_user_name(user_name_))
-        //     return util::Result{
-        //         util::status_code::BadRequest,
-        //         util::error_code::Invalid_username_format,
-        //         json{}
-        //     };
-
-        if (!is_vaild_password(password))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_password_format,
-                json{}
-            };
-
-        std::string password_hash;
-        try
-        {
-            password_hash = util::HASH(password);
-        }
-        catch (const std::exception &e)
-        {
-            util::cerr() << e.what() << std::endl;
-            util::log(util::LogFile::server, util::Level::ERROR) << e.what();
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-        }
-
-        if (const auto e = UserRegistrar::start(email, user_name, password_hash); e == 1)
-            return util::Result{
-                util::status_code::Conflict,
-                util::error_code::Email_already_registered,
-                json{}
-            };
-        else if (e == 2)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{
-                {"email", email},
-                {"user_name", user_name}
-            }
-        };
-    }
-
-    util::Result Binding::bind(const std::string &serial_number, const std::string &access_token)
-    {
-        token::DecodeAccessToken decode(access_token);
-        {
-            const auto code = decode.start();
-
-            if (code == 1)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_expired,
-                    json{}
-                };
-            if (code == 2)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_invalid,
-                    json{}
-                };
-            if (code == 3)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_signature,
-                    json{}
-                };
-            if (code == 4)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_token_supplied,
-                    json{}
-                };
-            if (code == 5)
-                return util::Result{
-                    util::status_code::InternalServerError,
-                    util::error_code::Internal_server_error,
-                    json{}
-                };
-        }
-
-        if (!is_vaild_serial_number(serial_number))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_serialnumber_format,
-                json{}
-            };
-
-        if (const auto a = EdgeIOSBindingRegistrar::bind(serial_number, decode.getUserId()); a == 1)
-            return util::Result{
-                util::status_code::Conflict,
-                util::error_code::Binding_already_exists,
-                json{}
-            };
-        else if (a == 2)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{
-                {"serial_number", serial_number}
-            }
-        };
-    }
-
-    util::Result Binding::unbind(const std::string &serial_number, const std::string &access_token)
-    {
-        token::DecodeAccessToken decode(access_token);
-        {
-            const auto code = decode.start();
-
-            if (code == 1)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_expired,
-                    json{}
-                };
-            if (code == 2)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_invalid,
-                    json{}
-                };
-            if (code == 3)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_signature,
-                    json{}
-                };
-            if (code == 4)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_token_supplied,
-                    json{}
-                };
-            if (code == 5)
-                return util::Result{
-                    util::status_code::InternalServerError,
-                    util::error_code::Internal_server_error,
-                    json{}
-                };
-        }
-
-        if (!is_vaild_serial_number(serial_number))
-            return util::Result{
-                util::status_code::BadRequest,
-                util::error_code::Invalid_serialnumber_format,
-                json{}
-            };
-
-        if (const auto a = EdgeIOSBindingRegistrar::unbind(
-            serial_number, decode.getUserId()); a == 1)
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{
-                    {"serial_number", serial_number}
-            }
-        };
-    }
-
-    util::Result GetUserInformation::run(const std::string &access_token)
-    {
-        token::DecodeAccessToken decode(access_token);
-        {
-            const auto code = decode.start();
-
-            if (code == 1)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_expired,
-                    json{}
-                };
-            if (code == 2)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::Access_Token_invalid,
-                    json{}
-                };
-            if (code == 3)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_signature,
-                    json{}
-                };
-            if (code == 4)
-                return util::Result{
-                    util::status_code::BadRequest,
-                    util::error_code::JWT_invalid_token_supplied,
-                    json{}
-                };
-            if (code == 5)
-                return util::Result{
-                    util::status_code::InternalServerError,
-                    util::error_code::Internal_server_error,
-                    json{}
-                };
-        }
-
-        const auto user_id = decode.getUserId();
-
-        const auto serial_number = UserEdgeListFinder::start(user_id);
-
-        const auto email = UserEmailFinder::start(user_id);
-        if (email.empty())
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-        const auto user_name = UserNameFinder::start_by_email(email);
-        if (user_name.empty())
-            return util::Result{
-                util::status_code::InternalServerError,
-                util::error_code::Internal_server_error,
-                json{}
-            };
-
-
-        return util::Result{
-            util::status_code::Success,
-            util::error_code::Success,
-            json{
-                {"user_name", user_name},
-                {"email", email},
-                {"serial_number", serial_number}
-            }
-        };
-    }
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"user_name", user_name}, {"access_token", AT.getAccessToken()}},
+                      RT.getRefreshToken()};
 }
+
+util::Result signup::run(const std::string &email, const std::string &user_name,
+                         const std::string &password) {
+  if (!is_vaild_email(email))
+    return util::Result{util::status_code::BadRequest, util::error_code::Invalid_email_format,
+                        json{}};
+
+  // if (!is_vaild_user_name(user_name_))
+  //     return util::Result{
+  //         util::status_code::BadRequest,
+  //         util::error_code::Invalid_username_format,
+  //         json{}
+  //     };
+
+  if (!is_vaild_password(password))
+    return util::Result{util::status_code::BadRequest, util::error_code::Invalid_password_format,
+                        json{}};
+
+  std::string password_hash;
+  try {
+    password_hash = util::HASH(password);
+  } catch (const std::exception &e) {
+    util::cerr() << e.what() << std::endl;
+    util::log(util::LogFile::server, util::Level::ERROR) << e.what();
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+  }
+
+  if (const auto e = UserRegistrar::start(email, user_name, password_hash); e == 1)
+    return util::Result{util::status_code::Conflict, util::error_code::Email_already_registered,
+                        json{}};
+  else if (e == 2)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"email", email}, {"user_name", user_name}}};
+}
+
+util::Result Binding::bind(const std::string &serial_number, const std::string &access_token) {
+  token::DecodeAccessToken decode(access_token);
+  {
+    const auto code = decode.start();
+
+    if (code == 1)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_expired,
+                          json{}};
+    if (code == 2)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_invalid,
+                          json{}};
+    if (code == 3)
+      return util::Result{util::status_code::BadRequest, util::error_code::JWT_invalid_signature,
+                          json{}};
+    if (code == 4)
+      return util::Result{util::status_code::BadRequest,
+                          util::error_code::JWT_invalid_token_supplied, json{}};
+    if (code == 5)
+      return util::Result{util::status_code::InternalServerError,
+                          util::error_code::Internal_server_error, json{}};
+  }
+
+  if (!is_vaild_serial_number(serial_number))
+    return util::Result{util::status_code::BadRequest,
+                        util::error_code::Invalid_serialnumber_format, json{}};
+
+  if (const auto a = EdgeIOSBindingRegistrar::bind(serial_number, decode.getUserId()); a == 1)
+    return util::Result{util::status_code::Conflict, util::error_code::Binding_already_exists,
+                        json{}};
+  else if (a == 2)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"serial_number", serial_number}}};
+}
+
+util::Result Binding::unbind(const std::string &serial_number, const std::string &access_token) {
+  token::DecodeAccessToken decode(access_token);
+  {
+    const auto code = decode.start();
+
+    if (code == 1)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_expired,
+                          json{}};
+    if (code == 2)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_invalid,
+                          json{}};
+    if (code == 3)
+      return util::Result{util::status_code::BadRequest, util::error_code::JWT_invalid_signature,
+                          json{}};
+    if (code == 4)
+      return util::Result{util::status_code::BadRequest,
+                          util::error_code::JWT_invalid_token_supplied, json{}};
+    if (code == 5)
+      return util::Result{util::status_code::InternalServerError,
+                          util::error_code::Internal_server_error, json{}};
+  }
+
+  if (!is_vaild_serial_number(serial_number))
+    return util::Result{util::status_code::BadRequest,
+                        util::error_code::Invalid_serialnumber_format, json{}};
+
+  if (const auto a = EdgeIOSBindingRegistrar::unbind(serial_number, decode.getUserId()); a == 1)
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  return util::Result{util::status_code::Success, util::error_code::Success,
+                      json{{"serial_number", serial_number}}};
+}
+
+util::Result GetUserInformation::run(const std::string &access_token) {
+  token::DecodeAccessToken decode(access_token);
+  {
+    const auto code = decode.start();
+
+    if (code == 1)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_expired,
+                          json{}};
+    if (code == 2)
+      return util::Result{util::status_code::BadRequest, util::error_code::Access_Token_invalid,
+                          json{}};
+    if (code == 3)
+      return util::Result{util::status_code::BadRequest, util::error_code::JWT_invalid_signature,
+                          json{}};
+    if (code == 4)
+      return util::Result{util::status_code::BadRequest,
+                          util::error_code::JWT_invalid_token_supplied, json{}};
+    if (code == 5)
+      return util::Result{util::status_code::InternalServerError,
+                          util::error_code::Internal_server_error, json{}};
+  }
+
+  const auto user_id = decode.getUserId();
+
+  const auto serial_number = UserEdgeListFinder::start(user_id);
+
+  const auto email = UserEmailFinder::start(user_id);
+  if (email.empty())
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  const auto user_name = UserNameFinder::start_by_email(email);
+  if (user_name.empty())
+    return util::Result{util::status_code::InternalServerError,
+                        util::error_code::Internal_server_error, json{}};
+
+  return util::Result{
+      util::status_code::Success, util::error_code::Success,
+      json{{"user_name", user_name}, {"email", email}, {"serial_number", serial_number}}};
+}
+}  // namespace redsafe::apiserver::service::User
 
 #endif

--- a/api-server/src/service/UserService.hpp
+++ b/api-server/src/service/UserService.hpp
@@ -17,55 +17,48 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 
 #include "../util/response.hpp"
 
-namespace redsafe::apiserver::service::User
-{
-    class signup
-    {
-    public:
-        [[nodiscard]] static util::Result run(
-            const std::string& email,
-            const std::string& user_name,
-            const std::string& password);
-    };
+namespace redsafe::apiserver::service::User {
+class signup {
+ public:
+  [[nodiscard]] static util::Result run(const std::string &email, const std::string &user_name,
+                                        const std::string &password);
+};
 
-    class signin
-    {
-    public:
-        /**
-         * @brief 使用 emal 和 password 登入
-         * @param email
-         * @param password
-         */
-        [[nodiscard]] static util::Result run(
-            const std::string &email,
-            const std::string &password);
-    };
+class signin {
+ public:
+  /**
+   * @brief 使用 emal 和 password 登入
+   * @param email
+   * @param password
+   */
+  [[nodiscard]] static util::Result run(const std::string &email, const std::string &password);
+};
 
-    class Binding
-    {
-    public:
-        [[nodiscard]] static util::Result bind   (const std::string &serial_number, const std::string &access_token);
-        [[nodiscard]] static util::Result unbind (const std::string &serial_number, const std::string &access_token);
-    };
+class Binding {
+ public:
+  [[nodiscard]] static util::Result bind(const std::string &serial_number,
+                                         const std::string &access_token);
+  [[nodiscard]] static util::Result unbind(const std::string &serial_number,
+                                           const std::string &access_token);
+};
 
-    /**
-     * @brief 獲取使用者資訊
-     */
-    class GetUserInformation
-    {
-    public:
-        /**
-         * @param access_token
-         * @return util::Result
-         */
-        [[nodiscard]] static util::Result run(const std::string &access_token);
+/**
+ * @brief 獲取使用者資訊
+ */
+class GetUserInformation {
+ public:
+  /**
+   * @param access_token
+   * @return util::Result
+   */
+  [[nodiscard]] static util::Result run(const std::string &access_token);
 
-        /// 禁止拷貝和移動
-        GetUserInformation(const GetUserInformation&)               = delete;
-        GetUserInformation(GetUserInformation&&)                    = delete;
-        GetUserInformation& operator=(const GetUserInformation&)    = delete;
-        GetUserInformation& operator=(GetUserInformation&&)         = delete;
-    };
-}
+  /// 禁止拷貝和移動
+  GetUserInformation(const GetUserInformation &) = delete;
+  GetUserInformation(GetUserInformation &&) = delete;
+  GetUserInformation &operator=(const GetUserInformation &) = delete;
+  GetUserInformation &operator=(GetUserInformation &&) = delete;
+};
+}  // namespace redsafe::apiserver::service::User
 
 #endif

--- a/api-server/src/util/IOstream.hpp
+++ b/api-server/src/util/IOstream.hpp
@@ -18,63 +18,52 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #include <iostream>
 #include <mutex>
 
-namespace redsafe::apiserver::util
-{
-    static std::mutex m_Mutex;
+namespace redsafe::apiserver::util {
+static std::mutex m_Mutex;
 
-    // ThreadSafe cout
-    // cout() << messafe;
-    struct cout
-    {
-        std::unique_lock<std::mutex> m_Lock;
+// ThreadSafe cout
+// cout() << messafe;
+struct cout {
+  std::unique_lock<std::mutex> m_Lock;
 
-        cout(): m_Lock(std::unique_lock(m_Mutex))
-        {
-        }
+  cout() : m_Lock(std::unique_lock(m_Mutex)) {}
 
-        explicit cout(const cout&) = delete;
-        ~cout() = default;
+  explicit cout(const cout &) = delete;
+  ~cout() = default;
 
-        template<typename T>
-        cout &operator<<(const T &message)
-        {
-            std::cout << message;
-            return *this;
-        }
+  template <typename T>
+  cout &operator<<(const T &message) {
+    std::cout << message;
+    return *this;
+  }
 
-        cout &operator<<(std::ostream & (*fp)(std::ostream &))
-        {
-            std::cout << fp;
-            return *this;
-        }
-    };
+  cout &operator<<(std::ostream &(*fp)(std::ostream &)) {
+    std::cout << fp;
+    return *this;
+  }
+};
 
-    // ThreadSafe cerr
-    // cerr() << messafe;
-    struct cerr
-    {
-        std::unique_lock<std::mutex> m_Lock;
+// ThreadSafe cerr
+// cerr() << messafe;
+struct cerr {
+  std::unique_lock<std::mutex> m_Lock;
 
-        cerr(): m_Lock(std::unique_lock(m_Mutex))
-        {
-        }
+  cerr() : m_Lock(std::unique_lock(m_Mutex)) {}
 
-        explicit cerr(const cerr&) = delete;
-        ~cerr() = default;
+  explicit cerr(const cerr &) = delete;
+  ~cerr() = default;
 
-        template<typename T>
-        cerr &operator<<(const T &message)
-        {
-            std::cerr << message;
-            return *this;
-        }
+  template <typename T>
+  cerr &operator<<(const T &message) {
+    std::cerr << message;
+    return *this;
+  }
 
-        cerr &operator<<(std::ostream & (*fp)(std::ostream &))
-        {
-            std::cerr << fp;
-            return *this;
-        }
-    };
-}
+  cerr &operator<<(std::ostream &(*fp)(std::ostream &)) {
+    std::cerr << fp;
+    return *this;
+  }
+};
+}  // namespace redsafe::apiserver::util
 
 #endif

--- a/api-server/src/util/crypto.hpp
+++ b/api-server/src/util/crypto.hpp
@@ -15,491 +15,414 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_CRYPTO_UTIL_HPP
 #define REDSAFE_CRYPTO_UTIL_HPP
 
-#include <sodium.h>
-#include <string>
-#include <vector>
-#include <stdexcept>
-#include <fstream>
-#include <cstdio>
-#include <openssl/evp.h>
 #include <openssl/aes.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
+#include <sodium.h>
+
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "../../config.hpp"
 
-namespace redsafe::apiserver::util
-{
-    /**
-    * @brief 把 input 內的二進位資料編成 Base64 (URL-safe, no padding) 字串
-    *
-    * @param input 任意 std::string，裡面可含二進位或純文字
-    * @return std::string 回傳 Base64 編碼後的字串
-    * @throws std::runtime_error 如果編碼失敗
-    */
-    inline std::string toBase64(const std::string &input)
-    {
-        // 第一步：確保 libsodium 已初始化
-        if (sodium_init() < 0)
-        {
-            throw std::runtime_error("libsodium 初始化失敗");
-        }
+namespace redsafe::apiserver::util {
+/**
+ * @brief 把 input 內的二進位資料編成 Base64 (URL-safe, no padding) 字串
+ *
+ * @param input 任意 std::string，裡面可含二進位或純文字
+ * @return std::string 回傳 Base64 編碼後的字串
+ * @throws std::runtime_error 如果編碼失敗
+ */
+inline std::string toBase64(const std::string &input) {
+  // 第一步：確保 libsodium 已初始化
+  if (sodium_init() < 0) {
+    throw std::runtime_error("libsodium 初始化失敗");
+  }
 
-        // 計算對應的 Base64 目的緩衝區大小
-        // sodium_base64_encoded_len(len, variant) 會回傳包含結尾 '\0' 的最小緩衝區長度
-        const size_t raw_len = input.size();
-        const size_t b64_buf_len = sodium_base64_encoded_len(raw_len, sodium_base64_VARIANT_URLSAFE_NO_PADDING);
+  // 計算對應的 Base64 目的緩衝區大小
+  // sodium_base64_encoded_len(len, variant) 會回傳包含結尾 '\0' 的最小緩衝區長度
+  const size_t raw_len = input.size();
+  const size_t b64_buf_len =
+      sodium_base64_encoded_len(raw_len, sodium_base64_VARIANT_URLSAFE_NO_PADDING);
 
-        // 配置一個足夠大的緩衝區
-        std::vector<char> b64buf(b64_buf_len);
+  // 配置一個足夠大的緩衝區
+  std::vector<char> b64buf(b64_buf_len);
 
-        const char *written = sodium_bin2base64(
-            b64buf.data(),
-            b64_buf_len,
-            reinterpret_cast<const unsigned char *>(input.data()),
-            raw_len,
-            sodium_base64_VARIANT_URLSAFE_NO_PADDING
-        );
+  const char *written = sodium_bin2base64(b64buf.data(), b64_buf_len,
+                                          reinterpret_cast<const unsigned char *>(input.data()),
+                                          raw_len, sodium_base64_VARIANT_URLSAFE_NO_PADDING);
 
-        if (written == nullptr)
-        {
-            throw std::runtime_error("Base64 編碼失敗");
-        }
+  if (written == nullptr) {
+    throw std::runtime_error("Base64 編碼失敗");
+  }
 
-        // b64buf 裡已經包含 NUL 結尾（'\0'），直接用 data() 建 std::string
-        return {b64buf.data()};
-    }
-
-    /**
-     * @brief 將 Base64 字串解碼回原始 std::string
-     *
-     * @param input Base64 編碼字串
-     * @return std::string 解碼後的原始二進位資料
-     * @throws std::runtime_error 如果解碼過程失敗
-     */
-    inline std::string fromBase64(const std::string &input)
-    {
-        // 確保 libsodium 已初始化
-        if (sodium_init() < 0)
-            throw std::runtime_error("libsodium 初始化失敗");
-
-        // 估算解碼後最大長度：Base64 長度 * 3/4 + 1
-        size_t input_len = input.size();
-        size_t raw_maxlen = input_len * 3 / 4 + 1;
-
-        // 配置足夠的緩衝區
-        std::vector<unsigned char> rawbuf(raw_maxlen);
-        size_t raw_len = 0;
-
-        // 呼叫 sodium_base642bin 進行解碼
-        if (sodium_base642bin(
-                rawbuf.data(),
-                raw_maxlen,
-                input.c_str(),
-                input_len,
-                nullptr,       // 不忽略任何字元
-                &raw_len,
-                nullptr,       // 不需要錯誤位置
-                sodium_base64_VARIANT_URLSAFE_NO_PADDING) != 0)
-            throw std::runtime_error("Base64 解碼失敗");
-
-        // 回傳解碼後的 std::string
-        return {reinterpret_cast<char*>(rawbuf.data()), raw_len};
-    }
-
-    /**
-     * @brief 將原始二進位資料轉換為十六進位字串 (每 byte 兩個 hex 字元)
-     *
-     * @param data 指向要編碼的原始二進位資料
-     * @param len  原始資料長度（單位：bytes）
-     * @return std::string 編碼後的十六進位字串 (長度 = len * 2)
-     */
-    static std::string toHex(const unsigned char *data, const size_t len)
-    {
-        static constexpr char hex[] = "0123456789ABCDEF";
-        std::string out;
-        out.reserve(len * 2);
-        for (size_t i = 0; i < len; ++i)
-        {
-            out.push_back(hex[data[i] >> 4]);
-            out.push_back(hex[data[i] & 0xF]);
-        }
-        return out;
-    }
-
-    /**
-     * @brief 將十六進位編碼字串還原為原始二進位資料
-     *
-     * @param hexStr 包含偶數個 0-9、A-F 或 a-f 字元的十六進位字串
-     * @return std::vector<unsigned char> 解碼後的原始二進位資料 (長度 = hexStr.size() / 2)
-     * @throws std::runtime_error 若 hexStr 長度非偶數或包含無效 hex 字元
-     */
-    static std::vector<unsigned char> fromHex(const std::string &hexStr)
-    {
-        if (hexStr.size() % 2)
-            throw std::runtime_error("Hex 字串長度必須為偶數");
-
-        auto hexVal = [](const char ch) -> int
-        {
-            if ('0' <= ch && ch <= '9') return ch - '0';
-            if ('A' <= ch && ch <= 'F') return ch - 'A' + 10;
-            if ('a' <= ch && ch <= 'f') return ch - 'a' + 10;
-            return -1;
-        };
-
-        std::vector<unsigned char> out(hexStr.size() / 2);
-        for (size_t i = 0; i < out.size(); ++i)
-        {
-            const int hi = hexVal(hexStr[2 * i]);
-            const int lo = hexVal(hexStr[2 * i + 1]);
-            if (hi < 0 || lo < 0)
-                throw std::runtime_error("Hex 字元無效");
-            out[i] = static_cast<unsigned char>((hi << 4) | lo);
-        }
-        return out;
-    }
-
-    /**
-     * @brief 管理 JWT 簽章金鑰，只執行一次載入或生成
-     */
-    class SecretManager
-    {
-    public:
-        /**
-         * @brief 取得單例實例
-         * Thread-Safe
-         * @return SecretManager& 單例物件
-         */
-        static SecretManager& instance()
-        {
-            static SecretManager inst;
-            return inst;
-        }
-
-        /**
-         * @brief 取得 Base64 編碼後的 JWT 簽章金鑰
-         * @return const std::string& 金鑰字串
-         */
-        [[nodiscard]] const std::string& getSecret() const
-        {
-            return secret_;
-        }
-
-        // 禁止複製與移動
-        SecretManager(const SecretManager &) = delete;
-        SecretManager &operator=(const SecretManager &) = delete;
-        SecretManager(SecretManager &&) = delete;
-        SecretManager &operator=(SecretManager &&) = delete;
-
-    private:
-        std::string secret_;
-
-        // 私有建構式：嘗試載入或生成金鑰
-        SecretManager()
-        {
-            // 確保 libsodium 已初始化
-            if (sodium_init() < 0)
-                throw std::runtime_error("libsodium 初始化失敗");
-
-            // 嘗試從檔案載入已存在的金鑰
-            if (std::ifstream infile(SECRET_FILE_PATH, std::ios::binary); infile.is_open())
-            {
-                std::string existingB64;
-                std::getline(infile, existingB64);
-                infile.close();
-                if (!existingB64.empty())
-                {
-                    secret_ = existingB64;
-                    return;
-                }
-            }
-
-            // 檔案不存在或為空，生成新的 32 字節隨機金鑰
-            constexpr size_t KEY_LEN = 32; // 256 位元
-            unsigned char buf[KEY_LEN];
-            randombytes_buf(buf, KEY_LEN); // 產生 KEY_LEN bytes 隨機
-
-            // 將隨機位元組轉成 Base64
-            std::string rawKey(reinterpret_cast<char*>(buf), KEY_LEN);
-            std::string b64 = toBase64(rawKey);
-
-            // 將 Base64 字串寫入檔案
-            std::ofstream outfile(SECRET_FILE_PATH, std::ios::out | std::ios::trunc);
-            if (!outfile.is_open())
-                throw std::runtime_error("無法寫入金鑰檔案: " + std::string(SECRET_FILE_PATH));
-            outfile << b64;
-            outfile.close();
-
-            secret_ = std::move(b64);
-        }
-    };
-
-    /**
-    * @brief 管理 AES-256-CBC 金鑰，只在第一次存取時讀取 AES_KEY.txt
-    */
-    class AESManager
-    {
-    public:
-        /// 取得 thread-safe 單例
-        static AESManager &instance()
-        {
-            static AESManager inst;
-            return inst;
-        }
-
-        /**
-         * @brief 加密 – 回傳十六進位字串（IV‖Ciphertext 轉 hex）
-         * @param plaintext 明文
-         * @return std::string hex-cipher
-         */
-        [[nodiscard]] std::string encrypt(const std::string &plaintext) const
-        {
-            // 1. 產生隨機 IV
-            unsigned char iv[AES_IV_LEN];
-            if (RAND_bytes(iv, AES_IV_LEN) != 1)
-                throw std::runtime_error("RAND_bytes 生成 IV 失敗");
-
-            // 2. 取得 thread‑local 的加密 context（只配置一次，之後重複使用）
-            thread_local EVP_CIPHER_CTX *ctx = []() {
-                EVP_CIPHER_CTX *p = EVP_CIPHER_CTX_new();
-                if (!p) throw std::runtime_error("EVP_CIPHER_CTX_new 失敗 (加密)");
-                return p;
-            }();
-            // 清空舊狀態，準備新一輪加密
-            EVP_CIPHER_CTX_reset(ctx);
-
-            if (EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr,
-                                   reinterpret_cast<const unsigned char *>(key_.data()),
-                                   iv
-                ) != 1)
-            {
-                throw std::runtime_error("EVP_EncryptInit_ex 失敗");
-            }
-
-            // 3. 執行加密
-            std::vector<unsigned char> cipherBuf(plaintext.size() + AES_BLOCK_SIZE);
-            int len1 = 0, len2 = 0;
-            const auto pt_size = plaintext.size();
-            if (pt_size > static_cast<std::size_t>(INT_MAX))
-            {
-                throw std::runtime_error("明文過長，超過 OpenSSL int 限制");
-            }
-
-            if (EVP_EncryptUpdate(ctx, cipherBuf.data(), &len1,
-                                  reinterpret_cast<const unsigned char *>(plaintext.data()),
-                                  static_cast<int>(pt_size)
-                ) != 1 ||
-                EVP_EncryptFinal_ex(ctx, cipherBuf.data() + len1, &len2) != 1)
-            {
-                throw std::runtime_error("EVP_EncryptUpdate/Final 失敗");
-            }
-
-            // 4. 組成 IV‖Ciphertext
-            const size_t cipherLen = len1 + len2;
-            std::vector<unsigned char> combined(AES_IV_LEN + cipherLen);
-            std::memcpy(combined.data(), iv, AES_IV_LEN);
-            std::memcpy(combined.data() + AES_IV_LEN, cipherBuf.data(), cipherLen);
-
-            return toHex(combined.data(), combined.size());
-        }
-
-        /**
-         * @brief 解密 – 參數為 encrypt() 產生的 hex 字串
-         * @param hexCipher IV ‖ Ciphertext（十六進位）
-         * @return std::string 明文
-         */
-        [[nodiscard]] std::string decrypt(const std::string &hexCipher) const
-        {
-            const std::vector<unsigned char> combined = fromHex(hexCipher);
-            if (combined.size() < AES_IV_LEN)
-                throw std::runtime_error("密文長度錯誤：缺少 IV");
-
-            const auto cipher_sz = combined.size() - AES_IV_LEN;
-            if (cipher_sz > static_cast<std::size_t>(INT_MAX))
-                throw std::runtime_error("密文過長，超過 OpenSSL int 限制");
-
-            const int cipherLen = static_cast<int>(cipher_sz);
-            const unsigned char *iv = combined.data();
-            const unsigned char *cipher = iv + AES_IV_LEN;
-
-            // 取得 thread‑local 的解密 context
-            thread_local EVP_CIPHER_CTX *ctx = []() {
-                EVP_CIPHER_CTX *p = EVP_CIPHER_CTX_new();
-                if (!p) throw std::runtime_error("EVP_CIPHER_CTX_new 失敗 (解密)");
-                return p;
-            }();
-            EVP_CIPHER_CTX_reset(ctx);
-
-            if (EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr,
-                                   reinterpret_cast<const unsigned char *>(key_.data()),
-                                   iv
-                ) != 1)
-            {
-                throw std::runtime_error("EVP_DecryptInit_ex 失敗");
-            }
-
-            std::vector<unsigned char> plainBuf(cipherLen);
-            int len1 = 0, len2 = 0;
-
-            if (EVP_DecryptUpdate(ctx, plainBuf.data(), &len1,
-                                  cipher, cipherLen
-                ) != 1 ||
-                EVP_DecryptFinal_ex(ctx, plainBuf.data() + len1, &len2) != 1)
-            {
-                throw std::runtime_error("EVP_DecryptUpdate/Final 失敗 (金鑰或資料錯誤)");
-            }
-
-            return {reinterpret_cast<char *>(plainBuf.data()), static_cast<std::string::size_type>(len1 + len2)};
-        }
-
-        // 禁止拷貝/移動
-        AESManager(const AESManager &) = delete;
-        AESManager &operator=(const AESManager &) = delete;
-        AESManager(AESManager &&) = delete;
-        AESManager &operator=(AESManager &&) = delete;
-
-    private:
-        static constexpr size_t AES_KEY_LEN = 32; // 256 bits
-        static constexpr size_t AES_IV_LEN = 16; // 128-bit IV
-
-        std::string key_; // raw 32 bytes
-
-        // 產生隨機 32‑byte 金鑰並寫入檔案（hex），然後存入 key_
-        void generateAndSaveKey()
-        {
-            unsigned char buf[AES_KEY_LEN];
-            if (RAND_bytes(buf, AES_KEY_LEN) != 1)
-                throw std::runtime_error("RAND_bytes 生成 AES key 失敗");
-
-            key_.assign(reinterpret_cast<char*>(buf), AES_KEY_LEN);
-
-            // 將金鑰轉為 hex 字串
-            const std::string hexKey = toHex(reinterpret_cast<unsigned char*>(buf), AES_KEY_LEN);
-
-            // 把 hex 字串寫到 AES_KEY.txt (文字模式)
-            std::ofstream out(AES_KEY_FILE_PATH, std::ios::out | std::ios::trunc);
-            if (!out.is_open())
-                throw std::runtime_error("無法建立 AES_KEY.txt 以寫入金鑰");
-            out << hexKey;
-            out.close();
-        }
-
-        /// 單例建構：只讀一次金鑰
-        AESManager()
-        {
-            // 嘗試讀取 AES_KEY.txt
-            std::ifstream in(AES_KEY_FILE_PATH, std::ios::binary);
-            if (!in.is_open())
-            {
-                // 檔案不存在：直接生成並寫檔 (hex)
-                generateAndSaveKey();
-                return;
-            }
-
-            std::string buf((std::istreambuf_iterator<char>(in)),
-                             std::istreambuf_iterator<char>());
-            in.close();
-
-            // 移除空白與換行
-            std::erase_if(buf,
-                          [](const char c){ return c=='\n'||c=='\r'||c==' '; });
-
-            // 僅接受 64 個 hex 字元
-            if (buf.size() == AES_KEY_LEN * 2)
-            {
-                std::vector<unsigned char> raw = fromHex(buf);
-                if (raw.size() == AES_KEY_LEN)
-                {
-                    key_.assign(reinterpret_cast<char*>(raw.data()), AES_KEY_LEN);
-                    return;
-                }
-            }
-
-            // 若到此代表檔案不合法，刪除後重建 (hex)
-            std::remove(AES_KEY_FILE_PATH);
-            generateAndSaveKey();
-       }
-    };
-
-    /**
-    * @brief 產生一個隨機 hex 字串
-    *
-    * @param byteLen 要產生多少原始隨機位元組（例如 32 = 256 bit）
-    * @return std::string 回傳的 hex 字串長度就是 byteLen * 2
-    * @throws std::runtime_error 如果 libsodium 初始化失敗
-    */
-    [[nodiscard]] inline std::string generateRandomHex(const std::size_t byteLen)
-    {
-        if (sodium_init() < 0)
-            throw std::runtime_error("libsodium 初始化失敗");
-
-        std::vector<unsigned char> buf(byteLen);
-        randombytes_buf(buf.data(), byteLen);
-
-
-        const std::size_t hexLen = byteLen * 2 + 1;
-        std::vector<char> hexBuf(hexLen);
-        sodium_bin2hex(
-            hexBuf.data(),
-            hexLen,
-            buf.data(),
-            byteLen
-        );
-
-        return {hexBuf.data()};
-    }
-
-    /**
-     * @brief  將明文雜湊
-     * @param  str  明文
-     * @return Argon2id 雜湊字串
-     */
-    [[nodiscard]] inline std::string HASH(std::string_view str)
-    {
-        if (sodium_init() < 0)
-            throw std::runtime_error("Failed to initialize password hashing library");
-        std::vector<char> hashBuf(crypto_pwhash_STRBYTES);
-        if (crypto_pwhash_str(
-                hashBuf.data(),
-                str.data(), str.size(),
-                crypto_pwhash_OPSLIMIT_INTERACTIVE,
-                crypto_pwhash_MEMLIMIT_INTERACTIVE
-            ) != 0)
-            throw std::runtime_error("Password hashing failed");
-        return {hashBuf.data()};
-    }
-
-    /**
-     * @brief  驗證明文密碼是否與儲存雜湊相符
-     * @param  hash   Argon2id 雜湊字串
-     * @param  str  明文
-     * @return true = 正確；false = 不符
-     */
-    [[nodiscard]] inline bool VerifyHASH(const std::string &hash, const std::string_view str)
-    {
-        if (sodium_init() < 0)
-            throw std::runtime_error("Failed to initialize sodium");
-        return crypto_pwhash_str_verify(
-                   hash.c_str(),
-                   str.data(),
-                   str.size()
-               ) == 0;
-    }
-
-    /**
-     * @brief 以 SHA‑256 產生固定十六進位雜湊；同字串每次結果都一致
-     *
-     * @param input 任意明文字串
-     * @return std::string 64 個大寫 hex 字元
-     */
-    [[nodiscard]] inline std::string SHA256_HEX(const std::string_view input)
-    {
-        unsigned char digest[SHA256_DIGEST_LENGTH];
-        SHA256(reinterpret_cast<const unsigned char*>(input.data()),
-               input.size(),
-               digest);
-        return toHex(digest, SHA256_DIGEST_LENGTH);
-    }
+  // b64buf 裡已經包含 NUL 結尾（'\0'），直接用 data() 建 std::string
+  return {b64buf.data()};
 }
+
+/**
+ * @brief 將 Base64 字串解碼回原始 std::string
+ *
+ * @param input Base64 編碼字串
+ * @return std::string 解碼後的原始二進位資料
+ * @throws std::runtime_error 如果解碼過程失敗
+ */
+inline std::string fromBase64(const std::string &input) {
+  // 確保 libsodium 已初始化
+  if (sodium_init() < 0) throw std::runtime_error("libsodium 初始化失敗");
+
+  // 估算解碼後最大長度：Base64 長度 * 3/4 + 1
+  size_t input_len = input.size();
+  size_t raw_maxlen = input_len * 3 / 4 + 1;
+
+  // 配置足夠的緩衝區
+  std::vector<unsigned char> rawbuf(raw_maxlen);
+  size_t raw_len = 0;
+
+  // 呼叫 sodium_base642bin 進行解碼
+  if (sodium_base642bin(rawbuf.data(), raw_maxlen, input.c_str(), input_len,
+                        nullptr,  // 不忽略任何字元
+                        &raw_len,
+                        nullptr,  // 不需要錯誤位置
+                        sodium_base64_VARIANT_URLSAFE_NO_PADDING) != 0)
+    throw std::runtime_error("Base64 解碼失敗");
+
+  // 回傳解碼後的 std::string
+  return {reinterpret_cast<char *>(rawbuf.data()), raw_len};
+}
+
+/**
+ * @brief 將原始二進位資料轉換為十六進位字串 (每 byte 兩個 hex 字元)
+ *
+ * @param data 指向要編碼的原始二進位資料
+ * @param len  原始資料長度（單位：bytes）
+ * @return std::string 編碼後的十六進位字串 (長度 = len * 2)
+ */
+static std::string toHex(const unsigned char *data, const size_t len) {
+  static constexpr char hex[] = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(len * 2);
+  for (size_t i = 0; i < len; ++i) {
+    out.push_back(hex[data[i] >> 4]);
+    out.push_back(hex[data[i] & 0xF]);
+  }
+  return out;
+}
+
+/**
+ * @brief 將十六進位編碼字串還原為原始二進位資料
+ *
+ * @param hexStr 包含偶數個 0-9、A-F 或 a-f 字元的十六進位字串
+ * @return std::vector<unsigned char> 解碼後的原始二進位資料 (長度 = hexStr.size() / 2)
+ * @throws std::runtime_error 若 hexStr 長度非偶數或包含無效 hex 字元
+ */
+static std::vector<unsigned char> fromHex(const std::string &hexStr) {
+  if (hexStr.size() % 2) throw std::runtime_error("Hex 字串長度必須為偶數");
+
+  auto hexVal = [](const char ch) -> int {
+    if ('0' <= ch && ch <= '9') return ch - '0';
+    if ('A' <= ch && ch <= 'F') return ch - 'A' + 10;
+    if ('a' <= ch && ch <= 'f') return ch - 'a' + 10;
+    return -1;
+  };
+
+  std::vector<unsigned char> out(hexStr.size() / 2);
+  for (size_t i = 0; i < out.size(); ++i) {
+    const int hi = hexVal(hexStr[2 * i]);
+    const int lo = hexVal(hexStr[2 * i + 1]);
+    if (hi < 0 || lo < 0) throw std::runtime_error("Hex 字元無效");
+    out[i] = static_cast<unsigned char>((hi << 4) | lo);
+  }
+  return out;
+}
+
+/**
+ * @brief 管理 JWT 簽章金鑰，只執行一次載入或生成
+ */
+class SecretManager {
+ public:
+  /**
+   * @brief 取得單例實例
+   * Thread-Safe
+   * @return SecretManager& 單例物件
+   */
+  static SecretManager &instance() {
+    static SecretManager inst;
+    return inst;
+  }
+
+  /**
+   * @brief 取得 Base64 編碼後的 JWT 簽章金鑰
+   * @return const std::string& 金鑰字串
+   */
+  [[nodiscard]] const std::string &getSecret() const { return secret_; }
+
+  // 禁止複製與移動
+  SecretManager(const SecretManager &) = delete;
+  SecretManager &operator=(const SecretManager &) = delete;
+  SecretManager(SecretManager &&) = delete;
+  SecretManager &operator=(SecretManager &&) = delete;
+
+ private:
+  std::string secret_;
+
+  // 私有建構式：嘗試載入或生成金鑰
+  SecretManager() {
+    // 確保 libsodium 已初始化
+    if (sodium_init() < 0) throw std::runtime_error("libsodium 初始化失敗");
+
+    // 嘗試從檔案載入已存在的金鑰
+    if (std::ifstream infile(SECRET_FILE_PATH, std::ios::binary); infile.is_open()) {
+      std::string existingB64;
+      std::getline(infile, existingB64);
+      infile.close();
+      if (!existingB64.empty()) {
+        secret_ = existingB64;
+        return;
+      }
+    }
+
+    // 檔案不存在或為空，生成新的 32 字節隨機金鑰
+    constexpr size_t KEY_LEN = 32;  // 256 位元
+    unsigned char buf[KEY_LEN];
+    randombytes_buf(buf, KEY_LEN);  // 產生 KEY_LEN bytes 隨機
+
+    // 將隨機位元組轉成 Base64
+    std::string rawKey(reinterpret_cast<char *>(buf), KEY_LEN);
+    std::string b64 = toBase64(rawKey);
+
+    // 將 Base64 字串寫入檔案
+    std::ofstream outfile(SECRET_FILE_PATH, std::ios::out | std::ios::trunc);
+    if (!outfile.is_open())
+      throw std::runtime_error("無法寫入金鑰檔案: " + std::string(SECRET_FILE_PATH));
+    outfile << b64;
+    outfile.close();
+
+    secret_ = std::move(b64);
+  }
+};
+
+/**
+ * @brief 管理 AES-256-CBC 金鑰，只在第一次存取時讀取 AES_KEY.txt
+ */
+class AESManager {
+ public:
+  /// 取得 thread-safe 單例
+  static AESManager &instance() {
+    static AESManager inst;
+    return inst;
+  }
+
+  /**
+   * @brief 加密 – 回傳十六進位字串（IV‖Ciphertext 轉 hex）
+   * @param plaintext 明文
+   * @return std::string hex-cipher
+   */
+  [[nodiscard]] std::string encrypt(const std::string &plaintext) const {
+    // 1. 產生隨機 IV
+    unsigned char iv[AES_IV_LEN];
+    if (RAND_bytes(iv, AES_IV_LEN) != 1) throw std::runtime_error("RAND_bytes 生成 IV 失敗");
+
+    // 2. 取得 thread‑local 的加密 context（只配置一次，之後重複使用）
+    thread_local EVP_CIPHER_CTX *ctx = []() {
+      EVP_CIPHER_CTX *p = EVP_CIPHER_CTX_new();
+      if (!p) throw std::runtime_error("EVP_CIPHER_CTX_new 失敗 (加密)");
+      return p;
+    }();
+    // 清空舊狀態，準備新一輪加密
+    EVP_CIPHER_CTX_reset(ctx);
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr,
+                           reinterpret_cast<const unsigned char *>(key_.data()), iv) != 1) {
+      throw std::runtime_error("EVP_EncryptInit_ex 失敗");
+    }
+
+    // 3. 執行加密
+    std::vector<unsigned char> cipherBuf(plaintext.size() + AES_BLOCK_SIZE);
+    int len1 = 0, len2 = 0;
+    const auto pt_size = plaintext.size();
+    if (pt_size > static_cast<std::size_t>(INT_MAX)) {
+      throw std::runtime_error("明文過長，超過 OpenSSL int 限制");
+    }
+
+    if (EVP_EncryptUpdate(ctx, cipherBuf.data(), &len1,
+                          reinterpret_cast<const unsigned char *>(plaintext.data()),
+                          static_cast<int>(pt_size)) != 1 ||
+        EVP_EncryptFinal_ex(ctx, cipherBuf.data() + len1, &len2) != 1) {
+      throw std::runtime_error("EVP_EncryptUpdate/Final 失敗");
+    }
+
+    // 4. 組成 IV‖Ciphertext
+    const size_t cipherLen = len1 + len2;
+    std::vector<unsigned char> combined(AES_IV_LEN + cipherLen);
+    std::memcpy(combined.data(), iv, AES_IV_LEN);
+    std::memcpy(combined.data() + AES_IV_LEN, cipherBuf.data(), cipherLen);
+
+    return toHex(combined.data(), combined.size());
+  }
+
+  /**
+   * @brief 解密 – 參數為 encrypt() 產生的 hex 字串
+   * @param hexCipher IV ‖ Ciphertext（十六進位）
+   * @return std::string 明文
+   */
+  [[nodiscard]] std::string decrypt(const std::string &hexCipher) const {
+    const std::vector<unsigned char> combined = fromHex(hexCipher);
+    if (combined.size() < AES_IV_LEN) throw std::runtime_error("密文長度錯誤：缺少 IV");
+
+    const auto cipher_sz = combined.size() - AES_IV_LEN;
+    if (cipher_sz > static_cast<std::size_t>(INT_MAX))
+      throw std::runtime_error("密文過長，超過 OpenSSL int 限制");
+
+    const int cipherLen = static_cast<int>(cipher_sz);
+    const unsigned char *iv = combined.data();
+    const unsigned char *cipher = iv + AES_IV_LEN;
+
+    // 取得 thread‑local 的解密 context
+    thread_local EVP_CIPHER_CTX *ctx = []() {
+      EVP_CIPHER_CTX *p = EVP_CIPHER_CTX_new();
+      if (!p) throw std::runtime_error("EVP_CIPHER_CTX_new 失敗 (解密)");
+      return p;
+    }();
+    EVP_CIPHER_CTX_reset(ctx);
+
+    if (EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr,
+                           reinterpret_cast<const unsigned char *>(key_.data()), iv) != 1) {
+      throw std::runtime_error("EVP_DecryptInit_ex 失敗");
+    }
+
+    std::vector<unsigned char> plainBuf(cipherLen);
+    int len1 = 0, len2 = 0;
+
+    if (EVP_DecryptUpdate(ctx, plainBuf.data(), &len1, cipher, cipherLen) != 1 ||
+        EVP_DecryptFinal_ex(ctx, plainBuf.data() + len1, &len2) != 1) {
+      throw std::runtime_error("EVP_DecryptUpdate/Final 失敗 (金鑰或資料錯誤)");
+    }
+
+    return {reinterpret_cast<char *>(plainBuf.data()),
+            static_cast<std::string::size_type>(len1 + len2)};
+  }
+
+  // 禁止拷貝/移動
+  AESManager(const AESManager &) = delete;
+  AESManager &operator=(const AESManager &) = delete;
+  AESManager(AESManager &&) = delete;
+  AESManager &operator=(AESManager &&) = delete;
+
+ private:
+  static constexpr size_t AES_KEY_LEN = 32;  // 256 bits
+  static constexpr size_t AES_IV_LEN = 16;   // 128-bit IV
+
+  std::string key_;  // raw 32 bytes
+
+  // 產生隨機 32‑byte 金鑰並寫入檔案（hex），然後存入 key_
+  void generateAndSaveKey() {
+    unsigned char buf[AES_KEY_LEN];
+    if (RAND_bytes(buf, AES_KEY_LEN) != 1) throw std::runtime_error("RAND_bytes 生成 AES key 失敗");
+
+    key_.assign(reinterpret_cast<char *>(buf), AES_KEY_LEN);
+
+    // 將金鑰轉為 hex 字串
+    const std::string hexKey = toHex(reinterpret_cast<unsigned char *>(buf), AES_KEY_LEN);
+
+    // 把 hex 字串寫到 AES_KEY.txt (文字模式)
+    std::ofstream out(AES_KEY_FILE_PATH, std::ios::out | std::ios::trunc);
+    if (!out.is_open()) throw std::runtime_error("無法建立 AES_KEY.txt 以寫入金鑰");
+    out << hexKey;
+    out.close();
+  }
+
+  /// 單例建構：只讀一次金鑰
+  AESManager() {
+    // 嘗試讀取 AES_KEY.txt
+    std::ifstream in(AES_KEY_FILE_PATH, std::ios::binary);
+    if (!in.is_open()) {
+      // 檔案不存在：直接生成並寫檔 (hex)
+      generateAndSaveKey();
+      return;
+    }
+
+    std::string buf((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+
+    // 移除空白與換行
+    std::erase_if(buf, [](const char c) { return c == '\n' || c == '\r' || c == ' '; });
+
+    // 僅接受 64 個 hex 字元
+    if (buf.size() == AES_KEY_LEN * 2) {
+      std::vector<unsigned char> raw = fromHex(buf);
+      if (raw.size() == AES_KEY_LEN) {
+        key_.assign(reinterpret_cast<char *>(raw.data()), AES_KEY_LEN);
+        return;
+      }
+    }
+
+    // 若到此代表檔案不合法，刪除後重建 (hex)
+    std::remove(AES_KEY_FILE_PATH);
+    generateAndSaveKey();
+  }
+};
+
+/**
+ * @brief 產生一個隨機 hex 字串
+ *
+ * @param byteLen 要產生多少原始隨機位元組（例如 32 = 256 bit）
+ * @return std::string 回傳的 hex 字串長度就是 byteLen * 2
+ * @throws std::runtime_error 如果 libsodium 初始化失敗
+ */
+[[nodiscard]] inline std::string generateRandomHex(const std::size_t byteLen) {
+  if (sodium_init() < 0) throw std::runtime_error("libsodium 初始化失敗");
+
+  std::vector<unsigned char> buf(byteLen);
+  randombytes_buf(buf.data(), byteLen);
+
+  const std::size_t hexLen = byteLen * 2 + 1;
+  std::vector<char> hexBuf(hexLen);
+  sodium_bin2hex(hexBuf.data(), hexLen, buf.data(), byteLen);
+
+  return {hexBuf.data()};
+}
+
+/**
+ * @brief  將明文雜湊
+ * @param  str  明文
+ * @return Argon2id 雜湊字串
+ */
+[[nodiscard]] inline std::string HASH(std::string_view str) {
+  if (sodium_init() < 0) throw std::runtime_error("Failed to initialize password hashing library");
+  std::vector<char> hashBuf(crypto_pwhash_STRBYTES);
+  if (crypto_pwhash_str(hashBuf.data(), str.data(), str.size(), crypto_pwhash_OPSLIMIT_INTERACTIVE,
+                        crypto_pwhash_MEMLIMIT_INTERACTIVE) != 0)
+    throw std::runtime_error("Password hashing failed");
+  return {hashBuf.data()};
+}
+
+/**
+ * @brief  驗證明文密碼是否與儲存雜湊相符
+ * @param  hash   Argon2id 雜湊字串
+ * @param  str  明文
+ * @return true = 正確；false = 不符
+ */
+[[nodiscard]] inline bool VerifyHASH(const std::string &hash, const std::string_view str) {
+  if (sodium_init() < 0) throw std::runtime_error("Failed to initialize sodium");
+  return crypto_pwhash_str_verify(hash.c_str(), str.data(), str.size()) == 0;
+}
+
+/**
+ * @brief 以 SHA‑256 產生固定十六進位雜湊；同字串每次結果都一致
+ *
+ * @param input 任意明文字串
+ * @return std::string 64 個大寫 hex 字元
+ */
+[[nodiscard]] inline std::string SHA256_HEX(const std::string_view input) {
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  SHA256(reinterpret_cast<const unsigned char *>(input.data()), input.size(), digest);
+  return toHex(digest, SHA256_DIGEST_LENGTH);
+}
+}  // namespace redsafe::apiserver::util
 
 #endif

--- a/api-server/src/util/logger.hpp
+++ b/api-server/src/util/logger.hpp
@@ -15,87 +15,74 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 #ifndef REDSAFE_LOGGER_UTIL_HPP
 #define REDSAFE_LOGGER_UTIL_HPP
 
-#include <string_view>
-#include <fstream>
-#include <sstream>
-#include <mutex>
 #include <array>
+#include <fstream>
+#include <mutex>
+#include <sstream>
 #include <string>
+#include <string_view>
 
 #include "timestamp.hpp"
 
-namespace redsafe::apiserver::util
-{
-    enum class Level    { INFO, WARNING, ERROR };
-    enum class LogFile  { server, access };
+namespace redsafe::apiserver::util {
+enum class Level { INFO, WARNING, ERROR };
+enum class LogFile { server, access };
 
-    constexpr std::string_view to_string(const Level lv) noexcept
-    {
-        switch (lv)
-        {
-            case Level::INFO:    return "INFO";
-            case Level::WARNING: return "WARNING";
-            case Level::ERROR:   return "ERROR";
-        }
-        return "UNKNOWN";
-    }
-
-    constexpr std::string_view to_string(const LogFile lg) noexcept
-    {
-        switch (lg)
-        {
-            case LogFile::server: return "server.log";
-            case LogFile::access: return "access.log";
-        }
-        return "UNKNOWN";
-    }
-
-    class LoggerManager
-    {
-    public:
-        static inline std::array<std::ofstream, 2> streams;
-        static inline std::mutex log_mutex;
-
-        static void init(LogFile file, const std::string &path)
-        {
-            std::lock_guard lock(log_mutex);
-            streams[static_cast<size_t>(file)].open(path, std::ios::app);
-        }
-    };
-
-    struct LogStream
-    {
-        Level lv;
-        LogFile file;
-        std::ostringstream oss;
-
-        LogStream(const LogFile file, const Level level) : lv(level), file(file)
-        {
-        }
-
-        template<typename T>
-        LogStream &operator<<(const T &value)
-        {
-            oss << value;
-            return *this;
-        }
-
-        ~LogStream()
-        {
-            std::lock_guard lock(LoggerManager::log_mutex);
-            auto &ofs = LoggerManager::streams[static_cast<size_t>(file)];
-            if (!ofs.is_open())
-                ofs.open(std::string(to_string(file)), std::ios::app);
-            ofs << current_timestamp()
-                << "[" << to_string(lv) << "] "
-                << oss.str() << std::endl;
-        }
-    };
-
-    inline LogStream log(const LogFile file, const Level level)
-    {
-        return LogStream{file, level};
-    }
+constexpr std::string_view to_string(const Level lv) noexcept {
+  switch (lv) {
+    case Level::INFO:
+      return "INFO";
+    case Level::WARNING:
+      return "WARNING";
+    case Level::ERROR:
+      return "ERROR";
+  }
+  return "UNKNOWN";
 }
+
+constexpr std::string_view to_string(const LogFile lg) noexcept {
+  switch (lg) {
+    case LogFile::server:
+      return "server.log";
+    case LogFile::access:
+      return "access.log";
+  }
+  return "UNKNOWN";
+}
+
+class LoggerManager {
+ public:
+  static inline std::array<std::ofstream, 2> streams;
+  static inline std::mutex log_mutex;
+
+  static void init(LogFile file, const std::string &path) {
+    std::lock_guard lock(log_mutex);
+    streams[static_cast<size_t>(file)].open(path, std::ios::app);
+  }
+};
+
+struct LogStream {
+  Level lv;
+  LogFile file;
+  std::ostringstream oss;
+
+  LogStream(const LogFile file, const Level level) : lv(level), file(file) {}
+
+  template <typename T>
+  LogStream &operator<<(const T &value) {
+    oss << value;
+    return *this;
+  }
+
+  ~LogStream() {
+    std::lock_guard lock(LoggerManager::log_mutex);
+    auto &ofs = LoggerManager::streams[static_cast<size_t>(file)];
+    if (!ofs.is_open()) ofs.open(std::string(to_string(file)), std::ios::app);
+    ofs << current_timestamp() << "[" << to_string(lv) << "] " << oss.str() << std::endl;
+  }
+};
+
+inline LogStream log(const LogFile file, const Level level) { return LogStream{file, level}; }
+}  // namespace redsafe::apiserver::util
 
 #endif

--- a/api-server/src/util/response.hpp
+++ b/api-server/src/util/response.hpp
@@ -17,59 +17,55 @@ Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved
 
 #include <nlohmann/json.hpp>
 
-namespace redsafe::apiserver::util
-{
-    enum class status_code : int
-    {
-        Success                = 200,
-        Created                = 201,
-        BadRequest             = 400,
-        Unauthorized           = 401,
-        Forbidden              = 403,
-        NotFound               = 404,
-        Conflict               = 409,
-        UnprocessableEntity    = 422,
-        InternalServerError    = 500,
-        ServiceUnavailable     = 503
-    };
+namespace redsafe::apiserver::util {
+enum class status_code : int {
+  Success = 200,
+  Created = 201,
+  BadRequest = 400,
+  Unauthorized = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Conflict = 409,
+  UnprocessableEntity = 422,
+  InternalServerError = 500,
+  ServiceUnavailable = 503
+};
 
-    enum class error_code : int
-    {
-        Success                                 = 0,
-        Unknown_endpoint                        = 99,
-        Invalid_JSON                            = 100,
-        Invalid_serialnumber_format             = 101,
-        Invalid_apnstoken_format                = 102,
-        Invalid_email_format                    = 103,
-        Invalid_username_format                 = 104,
-        Invalid_password_format                 = 105,
-        Email_or_Password_Error                 = 201,
-        Edge_device_already_registered          = 301,
-        Email_already_registered                = 302,
-        Binding_already_exists                  = 303,
-        Missing_serial_number_or_version        = 401,
-        Missing_email_or_user_name_or_password  = 402,
-        Missing_email_or_password               = 403,
-        Missing_user_id_or_apns_token           = 404,
-        Missing_serial_number                   = 405,
-        Missing_refresh_token                   = 406,
-        Missing_access_token                    = 407,
-        Internal_server_error                   = 500,
-        Refresh_Token_Expired                   = 501,
-        Refresh_Token_invalid                   = 502,
-        Access_Token_expired                    = 503,
-        Access_Token_invalid                    = 504,
-        JWT_invalid_signature                   = 505,
-        JWT_invalid_token_supplied              = 506
-    };
+enum class error_code : int {
+  Success = 0,
+  Unknown_endpoint = 99,
+  Invalid_JSON = 100,
+  Invalid_serialnumber_format = 101,
+  Invalid_apnstoken_format = 102,
+  Invalid_email_format = 103,
+  Invalid_username_format = 104,
+  Invalid_password_format = 105,
+  Email_or_Password_Error = 201,
+  Edge_device_already_registered = 301,
+  Email_already_registered = 302,
+  Binding_already_exists = 303,
+  Missing_serial_number_or_version = 401,
+  Missing_email_or_user_name_or_password = 402,
+  Missing_email_or_password = 403,
+  Missing_user_id_or_apns_token = 404,
+  Missing_serial_number = 405,
+  Missing_refresh_token = 406,
+  Missing_access_token = 407,
+  Internal_server_error = 500,
+  Refresh_Token_Expired = 501,
+  Refresh_Token_invalid = 502,
+  Access_Token_expired = 503,
+  Access_Token_invalid = 504,
+  JWT_invalid_signature = 505,
+  JWT_invalid_token_supplied = 506
+};
 
-    struct Result
-    {
-        status_code     sc;
-        error_code      ec;
-        nlohmann::json  body;
-        std::string     token{};
-    };
-}
+struct Result {
+  status_code sc;
+  error_code ec;
+  nlohmann::json body;
+  std::string token{};
+};
+}  // namespace redsafe::apiserver::util
 
 #endif

--- a/api-server/src/util/timestamp.hpp
+++ b/api-server/src/util/timestamp.hpp
@@ -1,14 +1,14 @@
 /******************************************************************************
    Copyright (C) 2025 by CHEN,BO-EN <chenboen931204@gmail.com>. All Rights Reserved.
-  
+
    This file and its contents are proprietary and confidential.
    Unauthorized reproduction, distribution, or modification is strictly prohibited.
-  
+
    Without the prior written permission of CHEN,BO-EN , you may not:
      1. Modify, adapt, or create derivative works of this source code;
      2. Reverse engineer, decompile, or otherwise attempt to derive the source code;
      3. Distribute, display, or otherwise use this source code or its derivatives in any form.
-  
+
    For licensing inquiries or to obtain a formal license, please contact:
 *******************************************************************************/
 
@@ -18,37 +18,31 @@
 #include <chrono>
 #include <iomanip>
 
-namespace redsafe::apiserver::util
-{
-    /**
-    *   [YYYY-MM-DD HH:MM:SS:mmm] or ISO
-    */
-    inline std::string current_timestamp(bool iso = false)
-    {
-        using namespace std::chrono;
-        const auto now = system_clock::now();
-        const auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
-        auto in_time_t = system_clock::to_time_t(now);
-        std::tm buf{};
+namespace redsafe::apiserver::util {
+/**
+ *   [YYYY-MM-DD HH:MM:SS:mmm] or ISO
+ */
+inline std::string current_timestamp(bool iso = false) {
+  using namespace std::chrono;
+  const auto now = system_clock::now();
+  const auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
+  auto in_time_t = system_clock::to_time_t(now);
+  std::tm buf{};
 #if defined(_WIN32) || defined(_WIN64)
-        localtime_s(&buf, &in_time_t);
+  localtime_s(&buf, &in_time_t);
 #else
-        localtime_r(&in_time_t, &buf);
+  localtime_r(&in_time_t, &buf);
 #endif
-        if (!iso)
-        {
-            std::ostringstream strTime;
-            strTime << '['
-                    << std::put_time(&buf, "%Y-%m-%d %H:%M:%S")
-                    << ':' << std::setw(3) << std::setfill('0') << ms.count()
-                    << "] ";
-            return strTime.str();
-        }
-        std::ostringstream strTime;
-        strTime << std::put_time(&buf, "%Y-%m-%dT%H:%M:%S")
-                << "+08:00";
-        return strTime.str();
-    }
+  if (!iso) {
+    std::ostringstream strTime;
+    strTime << '[' << std::put_time(&buf, "%Y-%m-%d %H:%M:%S") << ':' << std::setw(3)
+            << std::setfill('0') << ms.count() << "] ";
+    return strTime.str();
+  }
+  std::ostringstream strTime;
+  strTime << std::put_time(&buf, "%Y-%m-%dT%H:%M:%S") << "+08:00";
+  return strTime.str();
 }
+}  // namespace redsafe::apiserver::util
 
 #endif


### PR DESCRIPTION
## Summary
- add `.clang-format` with Folly-inspired settings
- reformat `api-server` C++ sources to use 2-space indentation and attached braces

## Testing
- `cmake ..` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_6842a24d531c832ea95e17d238f245d6