### PR TITLE
Add iOS device registration endpoint

### DIFF
--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/command/GlobalExceptionHandler.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/command/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.redsafetw.ios_service.command;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 全域異常處理器
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, Object> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+
+        String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        body.put("error_code", message);
+
+        return body;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleAllExceptions(Exception ex) {
+        String code = ex.getClass().getSimpleName().toUpperCase();
+        Map<String, Object> body = Map.of("error_code", code);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<?> handleRse(ResponseStatusException ex) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        String code = ex.getReason();
+        if (code == null || code.isBlank()) {
+            code = status.name();
+        }
+        return ResponseEntity.status(status).body(Map.of("error_code", code));
+    }
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/config/SecurityConfig.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.redsafetw.ios_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 安全性設定
+ */
+@Configuration
+public class SecurityConfig {
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/controller/IosController.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/controller/IosController.java
@@ -1,0 +1,29 @@
+package com.redsafetw.ios_service.controller;
+
+import com.redsafetw.ios_service.dto.IosRegisterRequest;
+import com.redsafetw.ios_service.dto.IosRegisterResponse;
+import com.redsafetw.ios_service.service.IosRegistrationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * iOS 控制器
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/ios", produces = MediaType.APPLICATION_JSON_VALUE)
+public class IosController {
+    private final IosRegistrationService iosRegistrationService;
+
+    @PostMapping(path = "/reg", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public IosRegisterResponse register(@RequestHeader(name = "Authorization", required = false) String authorization,
+                                        @Valid @RequestBody IosRegisterRequest request) {
+        return iosRegistrationService.registerDevice(authorization, request);
+    }
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/domain/IosDeviceDomain.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/domain/IosDeviceDomain.java
@@ -1,0 +1,48 @@
+package com.redsafetw.ios_service.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * iOS 裝置資料表對應
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "ios_devices")
+public class IosDeviceDomain {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "ios_device_id", nullable = false, updatable = false)
+    private UUID iosDeviceId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "apns_token", nullable = false, unique = true)
+    private String apnsToken;
+
+    @Column(name = "device_name")
+    private String deviceName;
+
+    @Column(name = "last_seen_at", nullable = false)
+    private OffsetDateTime lastSeenAt;
+
+    @PrePersist
+    @PreUpdate
+    public void touchLastSeenAt() {
+        this.lastSeenAt = OffsetDateTime.now();
+    }
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/dto/IosRegisterRequest.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/dto/IosRegisterRequest.java
@@ -1,0 +1,28 @@
+package com.redsafetw.ios_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * iOS 裝置註冊請求
+ */
+@Getter
+@Setter
+public class IosRegisterRequest {
+    @JsonProperty("ios_device_id")
+    private UUID iosDeviceId;
+
+    @JsonProperty("apns_token")
+    @NotBlank(message = "130")
+    @Size(max = 512, message = "131")
+    private String apnsToken;
+
+    @JsonProperty("device_name")
+    @Size(max = 255, message = "132")
+    private String deviceName;
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/dto/IosRegisterResponse.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/dto/IosRegisterResponse.java
@@ -1,0 +1,29 @@
+package com.redsafetw.ios_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * iOS 裝置註冊回應
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IosRegisterResponse {
+    @JsonProperty("ios_device_id")
+    private UUID iosDeviceId;
+
+    @JsonProperty("apns_token")
+    private String apnsToken;
+
+    @JsonProperty("device_name")
+    private String deviceName;
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/grpc/GrpcClientsConfig.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/grpc/GrpcClientsConfig.java
@@ -1,0 +1,18 @@
+package com.redsafetw.ios_service.grpc;
+
+import com.grpc.jwt.JwtServiceGrpc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.grpc.client.GrpcChannelFactory;
+
+/**
+ * gRPC 客戶端設定
+ */
+@Configuration
+public class GrpcClientsConfig {
+
+    @Bean
+    JwtServiceGrpc.JwtServiceBlockingStub jwtBlockingStub(GrpcChannelFactory channels) {
+        return JwtServiceGrpc.newBlockingStub(channels.createChannel("user"));
+    }
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/repository/IosDeviceRepository.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/repository/IosDeviceRepository.java
@@ -1,0 +1,18 @@
+package com.redsafetw.ios_service.repository;
+
+import com.redsafetw.ios_service.domain.IosDeviceDomain;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * iOS 裝置資料存取介面
+ */
+@Repository
+public interface IosDeviceRepository extends JpaRepository<IosDeviceDomain, UUID> {
+    Optional<IosDeviceDomain> findByIosDeviceIdAndUserId(UUID iosDeviceId, UUID userId);
+
+    Optional<IosDeviceDomain> findByApnsToken(String apnsToken);
+}

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/service/IosRegistrationService.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/service/IosRegistrationService.java
@@ -1,0 +1,118 @@
+package com.redsafetw.ios_service.service;
+
+import com.grpc.jwt.JwtServiceGrpc;
+import com.grpc.jwt.jwtchkRequset;
+import com.grpc.jwt.jwtchkResponse;
+import com.redsafetw.ios_service.domain.IosDeviceDomain;
+import com.redsafetw.ios_service.dto.IosRegisterRequest;
+import com.redsafetw.ios_service.dto.IosRegisterResponse;
+import com.redsafetw.ios_service.repository.IosDeviceRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * iOS 裝置註冊服務
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class IosRegistrationService {
+    private static final Logger log = LoggerFactory.getLogger(IosRegistrationService.class);
+
+    private final IosDeviceRepository iosDeviceRepository;
+    private final JwtServiceGrpc.JwtServiceBlockingStub jwtBlockingStub;
+
+    public IosRegisterResponse registerDevice(String authorization, IosRegisterRequest request) {
+        UUID userId = authenticate(authorization);
+
+        String sanitizedToken = request.getApnsToken().trim();
+
+        IosDeviceDomain device = resolveTargetDevice(userId, sanitizedToken, request.getIosDeviceId());
+        device.setUserId(userId);
+        device.setApnsToken(sanitizedToken);
+
+        String deviceName = request.getDeviceName();
+        device.setDeviceName(deviceName != null ? deviceName.trim() : null);
+        device.setLastSeenAt(OffsetDateTime.now());
+
+        IosDeviceDomain saved = iosDeviceRepository.save(device);
+        log.info("iOS device registered: deviceId={}, userId={}", saved.getIosDeviceId(), userId);
+
+        return IosRegisterResponse.builder()
+                .iosDeviceId(saved.getIosDeviceId())
+                .apnsToken(saved.getApnsToken())
+                .deviceName(saved.getDeviceName())
+                .build();
+    }
+
+    private UUID authenticate(String authorization) {
+        String token = extractToken(authorization);
+
+        jwtchkResponse response;
+        try {
+            response = jwtBlockingStub.check(jwtchkRequset.newBuilder().setJwt(token).build());
+        } catch (Exception ex) {
+            log.error("Failed to verify JWT via user-service", ex);
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "USER_SERVICE_UNAVAILABLE");
+        }
+
+        if (!response.getChk()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
+        }
+
+        try {
+            return UUID.fromString(response.getUserId());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Invalid user id returned from JWT service: {}", response.getUserId());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN");
+        }
+    }
+
+    private String extractToken(String authorization) {
+        if (authorization == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "MISSING_AUTHORIZATION_HEADER");
+        }
+
+        String[] parts = authorization.trim().split(" ", 2);
+        if (parts.length != 2 || !parts[0].equalsIgnoreCase("Bearer") || parts[1].isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_AUTHORIZATION_HEADER");
+        }
+
+        return parts[1].trim();
+    }
+
+    private IosDeviceDomain resolveTargetDevice(UUID userId, String apnsToken, UUID deviceId) {
+
+        if (deviceId != null) {
+            IosDeviceDomain existing = iosDeviceRepository.findByIosDeviceIdAndUserId(deviceId, userId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "IOS_DEVICE_NOT_FOUND"));
+
+            Optional<IosDeviceDomain> conflict = iosDeviceRepository.findByApnsToken(apnsToken);
+            if (conflict.isPresent() && !conflict.get().getIosDeviceId().equals(existing.getIosDeviceId())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "APNS_TOKEN_IN_USE");
+            }
+
+            return existing;
+        }
+
+        Optional<IosDeviceDomain> byToken = iosDeviceRepository.findByApnsToken(apnsToken);
+        if (byToken.isPresent()) {
+            IosDeviceDomain existing = byToken.get();
+            existing.setUserId(userId);
+            return existing;
+        }
+
+        IosDeviceDomain fresh = new IosDeviceDomain();
+        fresh.setUserId(userId);
+        return fresh;
+    }
+}

--- a/server/ios_service/src/main/proto/JwtService.proto
+++ b/server/ios_service/src/main/proto/JwtService.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package jwt;
+
+option java_multiple_files = true;
+option java_package = "com.grpc.jwt";
+option java_generic_services = true;
+
+service JwtService {
+  rpc Check(jwtchkRequset) returns (jwtchkResponse);
+}
+
+message jwtchkRequset {
+  string jwt = 1;
+}
+
+message jwtchkResponse {
+  bool chk = 1;
+  string user_id = 2;
+}

--- a/server/ios_service/src/main/resources/application.properties
+++ b/server/ios_service/src/main/resources/application.properties
@@ -1,1 +1,15 @@
 spring.application.name=ios_service
+server.port=30021
+spring.datasource.url=jdbc:postgresql://localhost:5432/redsafedb
+spring.datasource.username=redsafedb_user
+spring.datasource.password=redsafedb_1204
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
+logging.level.org.hibernate=warn
+logging.level.org.hibernate.SQL=off
+logging.level.org.hibernate.orm.jdbc.bind=off
+logging.level.org.hibernate.type.descriptor.sql=off
+
+spring.grpc.client.channels.user.address=static://localhost:30002
+spring.grpc.client.channels.user.negotiation-type=PLAINTEXT


### PR DESCRIPTION
## Summary
- add a `/ios/reg` endpoint that verifies bearer tokens via the user-service gRPC and registers iOS devices
- persist iOS device details with validation, JPA mappings, and conflict handling for APNS tokens
- configure the iOS service with datasource, security, gRPC client, and shared JWT proto definition