### PR TITLE
Add Spring Cloud gateway and Eureka discovery

### DIFF
--- a/server/edge_service/pom.xml
+++ b/server/edge_service/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <java.version>17</java.version>
         <spring-grpc.version>0.10.0</spring-grpc.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -36,6 +37,13 @@
                 <groupId>org.springframework.grpc</groupId>
                 <artifactId>spring-grpc-dependencies</artifactId>
                 <version>${spring-grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -130,6 +138,10 @@
             <artifactId>annotations</artifactId>
             <version>RELEASE</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/server/edge_service/src/main/java/com/redsafetw/edge_service/EdgeServiceApplication.java
+++ b/server/edge_service/src/main/java/com/redsafetw/edge_service/EdgeServiceApplication.java
@@ -2,8 +2,10 @@ package com.redsafetw.edge_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class EdgeServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(EdgeServiceApplication.class, args);

--- a/server/edge_service/src/main/resources/application.properties
+++ b/server/edge_service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=edge_service
+spring.application.name=edge-service
 server.port=30011
 spring.grpc.server.port=30012
 spring.datasource.url=jdbc:postgresql://localhost:5432/redsafedb
@@ -11,3 +11,7 @@ logging.level.org.hibernate=warn
 logging.level.org.hibernate.SQL=off
 logging.level.org.hibernate.orm.jdbc.bind=off
 logging.level.org.hibernate.type.descriptor.sql=off
+
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka
+eureka.instance.prefer-ip-address=true
+eureka.instance.metadata-map.grpc.port=${spring.grpc.server.port}

--- a/server/gateway/pom.xml
+++ b/server/gateway/pom.xml
@@ -28,11 +28,37 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <dependency>

--- a/server/gateway/src/main/java/com/redsafetw/gateway/GatewayApplication.java
+++ b/server/gateway/src/main/java/com/redsafetw/gateway/GatewayApplication.java
@@ -2,12 +2,16 @@ package com.redsafetw.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class GatewayApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(GatewayApplication.class, args);
+        SpringApplication app = new SpringApplication(GatewayApplication.class);
+        app.setAdditionalProfiles("gateway");
+        app.run(args);
     }
 
 }

--- a/server/gateway/src/main/java/com/redsafetw/gateway/ServiceRegistryApplication.java
+++ b/server/gateway/src/main/java/com/redsafetw/gateway/ServiceRegistryApplication.java
@@ -1,0 +1,16 @@
+package com.redsafetw.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class ServiceRegistryApplication {
+
+    public static void main(String[] args) {
+        SpringApplication app = new SpringApplication(ServiceRegistryApplication.class);
+        app.setAdditionalProfiles("registry");
+        app.run(args);
+    }
+}

--- a/server/gateway/src/main/resources/application.properties
+++ b/server/gateway/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=gateway

--- a/server/gateway/src/main/resources/application.yml
+++ b/server/gateway/src/main/resources/application.yml
@@ -1,0 +1,65 @@
+spring:
+  application:
+    name: gateway
+
+---
+spring:
+  config:
+    activate:
+      on-profile: gateway
+  application:
+    name: api-gateway
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: false
+      routes:
+        - id: user-service
+          uri: lb://user-service
+          predicates:
+            - Path=/user/**
+        - id: edge-service
+          uri: lb://edge-service
+          predicates:
+            - Path=/edge/**
+        - id: ios-service
+          uri: lb://ios-service
+          predicates:
+            - Path=/ios/**
+server:
+  port: 8080
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: registry
+  application:
+    name: service-registry
+server:
+  port: 8761
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+  server:
+    wait-time-in-ms-when-sync-empty: 0
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/server/ios_service/pom.xml
+++ b/server/ios_service/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <java.version>17</java.version>
         <spring-grpc.version>0.10.0</spring-grpc.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -36,6 +37,13 @@
                 <groupId>org.springframework.grpc</groupId>
                 <artifactId>spring-grpc-dependencies</artifactId>
                 <version>${spring-grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -124,6 +132,10 @@
         <dependency>
             <groupId>org.springframework.grpc</groupId>
             <artifactId>spring-grpc-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/server/ios_service/src/main/java/com/redsafetw/ios_service/IosServiceApplication.java
+++ b/server/ios_service/src/main/java/com/redsafetw/ios_service/IosServiceApplication.java
@@ -2,8 +2,10 @@ package com.redsafetw.ios_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class IosServiceApplication {
 
     public static void main(String[] args) {

--- a/server/ios_service/src/main/resources/application.properties
+++ b/server/ios_service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=ios_service
+spring.application.name=ios-service
 server.port=30021
 spring.datasource.url=jdbc:postgresql://localhost:5432/redsafedb
 spring.datasource.username=redsafedb_user
@@ -11,5 +11,8 @@ logging.level.org.hibernate.SQL=off
 logging.level.org.hibernate.orm.jdbc.bind=off
 logging.level.org.hibernate.type.descriptor.sql=off
 
-spring.grpc.client.channels.user.address=static://localhost:30002
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka
+eureka.instance.prefer-ip-address=true
+
+spring.grpc.client.channels.user.address=discovery://user-service
 spring.grpc.client.channels.user.negotiation-type=PLAINTEXT

--- a/server/user_service/pom.xml
+++ b/server/user_service/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <java.version>17</java.version>
         <spring-grpc.version>0.10.0</spring-grpc.version>
+        <spring-cloud.version>2024.0.0</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -36,6 +37,13 @@
                 <groupId>org.springframework.grpc</groupId>
                 <artifactId>spring-grpc-dependencies</artifactId>
                 <version>${spring-grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -124,6 +132,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/server/user_service/src/main/java/com/redsafetw/user_service/UserServiceApplication.java
+++ b/server/user_service/src/main/java/com/redsafetw/user_service/UserServiceApplication.java
@@ -2,8 +2,10 @@ package com.redsafetw.user_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class UserServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);

--- a/server/user_service/src/main/resources/application.properties
+++ b/server/user_service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=user_service
+spring.application.name=user-service
 server.port=30001
 spring.grpc.server.port=30002
 spring.datasource.url=jdbc:postgresql://localhost:5432/redsafedb
@@ -12,6 +12,9 @@ logging.level.org.hibernate.SQL=off
 logging.level.org.hibernate.orm.jdbc.bind=off
 logging.level.org.hibernate.type.descriptor.sql=off
 
-# user-service 作為客戶端
-spring.grpc.client.channels.edge.address=static://localhost:30012
+eureka.client.service-url.defaultZone=http://localhost:8761/eureka
+eureka.instance.prefer-ip-address=true
+eureka.instance.metadata-map.grpc.port=${spring.grpc.server.port}
+
+spring.grpc.client.channels.edge.address=discovery://edge-service
 spring.grpc.client.channels.edge.negotiation-type=PLAINTEXT


### PR DESCRIPTION
## Summary
- add Spring Cloud Gateway and an embedded Eureka registry to the gateway service with profile-based configuration
- enable Eureka discovery across user, edge, and iOS services and update their Spring Cloud dependencies
- configure gRPC clients to resolve peers through Eureka registration metadata