### PR TITLE
Refactor edge setup to use PostgreSQL config table

### DIFF
--- a/raspberry_web/raspberry_contral/ui/admin.py
+++ b/raspberry_web/raspberry_contral/ui/admin.py
@@ -1,15 +1,9 @@
 from django.contrib import admin
-from .models import SetupConfig, BoundUser
 
-@admin.register(SetupConfig)
-class SetupConfigAdmin(admin.ModelAdmin):
-    list_display = ("id", "password_plain", "created_at")
-    ordering = ("-id",)
-    search_fields = ("id", "password_plain")
+from .models import EdgeConfig
 
-@admin.register(BoundUser)
-class BoundUserAdmin(admin.ModelAdmin):
-    list_display = ("id", "email", "user_name", "created_at", "last_seen")
-    search_fields = ("email", "user_name")
-    list_filter = ("created_at",)
-    ordering = ("-created_at",)
+
+@admin.register(EdgeConfig)
+class EdgeConfigAdmin(admin.ModelAdmin):
+    list_display = ("edge_id", "edge_password")
+    search_fields = ("edge_id",)

--- a/raspberry_web/raspberry_contral/ui/models.py
+++ b/raspberry_web/raspberry_contral/ui/models.py
@@ -1,31 +1,12 @@
 from django.db import models
 
-class SetupConfig(models.Model):
-    # 明碼存放
-    password_plain = models.CharField(max_length=128, default="RedSafe123")
-    created_at = models.DateTimeField(auto_now_add=True)
 
-    def __str__(self):
-        return f"{self.id}: {self.password_plain}"
+class EdgeConfig(models.Model):
+    """對應 PostgreSQL 中的 config 表，僅存放 edge 資訊。"""
 
-class BoundUser(models.Model):
-    email = models.EmailField(unique=True, db_index=True, verbose_name="Email")
-    user_name = models.CharField(max_length=100, verbose_name="使用者名稱")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="綁定時間")
-    last_seen = models.DateTimeField(null=True, blank=True, verbose_name="上次上線")
-
-    class Meta:
-        ordering = ["-created_at"]
-        verbose_name = "綁定使用者"
-        verbose_name_plural = "綁定使用者"
-
-    def __str__(self):
-        return f"{self.user_name} <{self.email}>"
-
-class PgConfig(models.Model):
     edge_id = models.TextField(primary_key=True)
-    edge_password = models.TextField()
+    edge_password = models.TextField(blank=True, null=True)
 
     class Meta:
-        db_table = "config"   # 就是你在 Postgres 建的這張
-        managed = False       # 既有表，Django 不會替你建/改它
+        db_table = "config"
+        managed = False


### PR DESCRIPTION
## Summary
- replace legacy models and admin configuration so the UI only references the existing PostgreSQL `config` table
- update setup, login, and device password flows to read/write the `config` row and call the remote registration API
- clean up views to remove unused database logic and add Chinese docstrings for each function

## Testing
- python manage.py check *(fails: Django not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de34c9e63c832ebb3dd6184cc3b692